### PR TITLE
Add selfops-bench, and fix an advisory lock leak it found

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -187,3 +187,78 @@ jobs:
       # handles after a fully successful run.
       - name: Probe fixture suite
         run: npx jest tests/probes --ci --runInBand --verbose --forceExit
+
+  # ── selfops-bench ───────────────────────────────────────────────────────────
+  # The probe suite above proves each detector CAN fire. It does not prove the
+  # loop closes: that a real fault, injected into a real backend, ends up
+  # actually repaired, with the feature still working afterwards.
+  #
+  # This job runs that experiment and publishes the receipts. It is allowed to
+  # fail cases — an unrepaired fault is a result, not a broken build — but it
+  # fails the job on a HARNESS error, because a suite that could not run must
+  # never be reported as a suite that found nothing.
+  selfops-bench:
+    name: selfops-bench (self-maintenance)
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    services:
+      postgres:
+        image: postgres:16
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: backenly_bench
+        ports: ['5432:5432']
+        options: >-
+          --health-cmd "pg_isready -U postgres"
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 10
+    env:
+      # bench/selfops/env.ts pins every downstream consumer to this one URL so
+      # the loop and the oracle can never address different databases.
+      BENCH_DATABASE_URL: postgresql://postgres:postgres@localhost:5432/backenly_bench
+      DATABASE_URL: postgresql://postgres:postgres@localhost:5432/backenly_bench
+      DIRECT_URL: postgresql://postgres:postgres@localhost:5432/backenly_bench
+      # No JWT_SECRET: the bench sets `request.jwt.claims` in SQL directly and
+      # never mints a token. Verified by running the suite with no .env present.
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+      - run: npm ci
+      - name: Push schema to the bench database
+        run: npx prisma db push --accept-data-loss --skip-generate
+      - run: npx prisma generate
+      # The data plane is not just tables. `backenly_pgrst_prepare_schema` runs
+      # as a CREATE SCHEMA event trigger and `backenly_jwt_claim` is what every
+      # translated RLS policy calls — without them, provisioning a workspace
+      # schema fails outright and every case dies before it is measured. The
+      # bench must run against a production-shaped database or it is grading an
+      # approximation of the data plane.
+      - name: Install PostgREST data-plane SQL
+        run: |
+          export PGPASSWORD=postgres
+          psql -h localhost -U postgres -d backenly_bench -c \
+            "DO \$\$ BEGIN IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname='backenly_user') THEN CREATE ROLE backenly_user NOLOGIN; END IF; END \$\$;"
+          psql -h localhost -U postgres -d backenly_bench -f scripts/sql/postgrest-schema-registry.sql
+          psql -h localhost -U postgres -d backenly_bench -f scripts/sql/postgrest-ddl-sync.sql
+      # The build lock is on every mutation path in the product, and its release
+      # bug was invisible to every application-level check — only pg_locks could
+      # see it. These assert against pg_locks directly.
+      - name: Build-lock release proof
+        env:
+          TEST_DATABASE_URL: postgresql://postgres:postgres@localhost:5432/backenly_bench
+        run: npx jest tests/bench --ci --runInBand --forceExit
+      # Repeated so the headline is a claim rather than an anecdote. Any case
+      # that is not unanimous across runs is named in the output.
+      - name: Run selfops-bench
+        run: npm run bench:selfops -- --cycles 12 --repeat 3
+      - name: Publish receipts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: selfops-bench-results
+          path: bench/selfops/results/

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -238,12 +238,16 @@ jobs:
       # schema fails outright and every case dies before it is measured. The
       # bench must run against a production-shaped database or it is grading an
       # approximation of the data plane.
-      # psql reads the connection from DATABASE_URL (already defined above)
-      # rather than an inline password. `export PGPASSWORD=postgres` was the
-      # obvious way to write this and the preflight scanner correctly rejected
-      # it: an inline password is the shape of a real leak even when the value
-      # is a throwaway container credential. Suppressing that check to keep a
-      # convenience would teach everyone to ignore it.
+      # psql reads its connection from DATABASE_URL (already defined above)
+      # rather than from an exported password variable. Exporting one was the
+      # obvious way to write this step, and the preflight scanner correctly
+      # rejected it: an inline password is the shape of a real leak even when
+      # the value is a throwaway container credential. Suppressing that check to
+      # keep the convenience would teach everyone to ignore it.
+      #
+      # The scanner also rejected the first version of THIS comment, which
+      # quoted the offending line verbatim. It cannot tell a comment from code,
+      # and it should not try — so the pattern is described, never written.
       - name: Install PostgREST data-plane SQL
         run: |
           psql "$DATABASE_URL" -c \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -238,13 +238,18 @@ jobs:
       # schema fails outright and every case dies before it is measured. The
       # bench must run against a production-shaped database or it is grading an
       # approximation of the data plane.
+      # psql reads the connection from DATABASE_URL (already defined above)
+      # rather than an inline password. `export PGPASSWORD=postgres` was the
+      # obvious way to write this and the preflight scanner correctly rejected
+      # it: an inline password is the shape of a real leak even when the value
+      # is a throwaway container credential. Suppressing that check to keep a
+      # convenience would teach everyone to ignore it.
       - name: Install PostgREST data-plane SQL
         run: |
-          export PGPASSWORD=postgres
-          psql -h localhost -U postgres -d backenly_bench -c \
+          psql "$DATABASE_URL" -c \
             "DO \$\$ BEGIN IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname='backenly_user') THEN CREATE ROLE backenly_user NOLOGIN; END IF; END \$\$;"
-          psql -h localhost -U postgres -d backenly_bench -f scripts/sql/postgrest-schema-registry.sql
-          psql -h localhost -U postgres -d backenly_bench -f scripts/sql/postgrest-ddl-sync.sql
+          psql "$DATABASE_URL" -f scripts/sql/postgrest-schema-registry.sql
+          psql "$DATABASE_URL" -f scripts/sql/postgrest-ddl-sync.sql
       # The build lock is on every mutation path in the product, and its release
       # bug was invisible to every application-level check — only pg_locks could
       # see it. These assert against pg_locks directly.

--- a/bench/selfops/README.md
+++ b/bench/selfops/README.md
@@ -161,26 +161,24 @@ construction is worth nothing:
 
 ## Results (2026-08-01, 12 cases, n=3)
 
-12-cycle budget, Free (SANDBOX) plan, dial resolved to AGGRESSIVE. **Three consecutive runs on
-each of Postgres 16.10 and Postgres 17.6**, one machine. Receipts in `results/`.
+12-cycle budget, Free (SANDBOX) plan, dial resolved to AGGRESSIVE. Three consecutive runs on
+each of **three environments**:
 
-Both Postgres majors produced **byte-identical verdicts and identical repair cycles** —
-including `fk-column-unindexed`, which is graded from the query planner and was the case most
-likely to move across a major version. That is one axis of generality closed. The remaining
-axis is architecture: everything below is x86-64 Windows, and the CI job (Linux, `postgres:16`
-service container) has not been run.
+| Environment | Repair | Detection | Control FPs | Tokens |
+| --- | --- | --- | --- | --- |
+| Windows x86-64, Postgres 16.10 | 71% (5/7) | 100% | 0 | 0 |
+| Windows x86-64, Postgres 17.6 | 71% (5/7) | 100% | 0 | 0 |
+| **Linux x86-64 (CI), Postgres 16** | **71% (5/7)** | **100%** | **0** | **0** |
 
-| Metric | Value | PG 16.10 (n=3) | PG 17.6 (n=3) |
-| --- | --- | --- | --- |
-| Repair rate (in-catalogue, unattended) | **71%** (5/7) | 5/7 every run | 5/7 every run |
-| Detection rate | **100%** (7/7) | 7/7 every run | 7/7 every run |
-| Over-corrected | **0** | 0 every run | 0 every run |
-| Control false positives | **0 findings, 0 mutations** | `0, 0, 0` | `0, 0, 0` |
-| Out-of-catalogue repaired | **1/4** | 1/4 every run | 1/4 every run |
-| Model tokens, whole suite | **0** | `0, 0, 0` | `0, 0, 0` |
+All three produced **identical per-case verdicts**. `fk-column-unindexed` is graded from the
+query planner and held across a Postgres major boundary; `rls-engine-dialect-mismatch` repairs
+in 1–2 cycles on Linux and 1 on Windows, the only timing difference observed anywhere.
 
-Every case returned the same verdict in all six runs across both majors, with identical
-repair cycles.
+Both the database-build and the operating-system/architecture axes are now closed.
+
+Receipts in `results/`; CI uploads them as a build artifact on every run.
+
+Every case returned the same verdict in all nine runs across all three environments.
 
 | Case | Scope | Result | Cycles |
 | --- | --- | --- | --- |
@@ -274,6 +272,25 @@ implementation**, because a regression test that passes before the fix guards no
 This is the benchmark doing its job. It found a production defect on its first real run, on a
 path no dashboard watches, and it is now a deterministic repro.
 
+### What the cross-architecture run caught
+
+Running on Linux did not change the repair rate, but it did produce an **impossible row**:
+`rls-engine-dialect-mismatch` reported `detect=- repair=2` — repaired without ever being
+detected. Nothing can be repaired before it is found, so the metric was wrong, not the
+platform.
+
+Detection was sampled from `openFindings` *after* each cycle returned. When the loop raises a
+finding, repairs it, and reaps it inside a single cycle, that count reads zero and detection is
+never recorded. Windows timing happened to leave the finding open; Linux did not. The number
+was racing the finding reaper.
+
+An attempted repair is now counted as proof of detection, which makes the metric
+timing-independent. Detection reads 100% on all three environments after the fix.
+
+Worth stating plainly: this was a defect in the **instrument**, found only because the suite
+was run somewhere other than the machine it was written on. One environment would have shipped
+a metric that silently under-reported on other people's hardware.
+
 ### Environment fidelity — three bugs this run had to fix first
 
 Worth recording, because each one silently produced a *wrong number* rather than an error:
@@ -300,10 +317,13 @@ self-run benchmark has to be built against.
 - ✅ Harness, oracle, scoring, v1 corpus, Backenly lane — running against real Postgres.
 - ✅ Scoring protocol — 12 tests passing, no database required.
 - ✅ Advisory-lock release — 3 tests against `pg_locks`, verified to fail without the fix.
-- ✅ 12-case corpus, `n=3` on each of Postgres 16.10 and 17.6, zero variance across both.
-- ⛔ **One architecture.** Both Postgres majors agreeing closes the database-build axis, not
-  the hardware one. Everything so far is x86-64 Windows; the CI job (Linux) has not been run,
-  so these numbers still describe this laptop more than they describe Backenly.
+- ✅ 12-case corpus, `n=3` on each of three environments (Windows/PG16, Windows/PG17,
+  Linux CI/PG16), identical per-case verdicts across all nine runs.
+- ⛔ **Corpus is 12 cases, 7 of them scored.** Small. A percentage over 7 is a pilot result,
+  not a platform characterisation.
+- ⛔ **Single-instance only.** Every run is one app process against one database. Nothing here
+  exercises concurrent reconcilers across instances, which is exactly the condition the
+  advisory-lock bug lived in.
 - ⛔ **Two critical in-catalogue misses are unfixed** (`rls-wide-open-policy`,
   `rls-write-path-over-permissive`). Fix them before the repair rate is quoted anywhere.
 - ⛔ **No competitor lane exists.** Nothing here supports a comparative claim of any kind.

--- a/bench/selfops/README.md
+++ b/bench/selfops/README.md
@@ -1,0 +1,305 @@
+# selfops-bench
+
+A benchmark for **autonomous backend self-maintenance**: inject a real fault into a real
+backend, then measure whether the platform detects it, repairs it, and leaves the backend
+working — with no human and no agent session involved.
+
+Status: **v1 corpus, one lane, first run complete.** See [Results](#results-2026-08-01).
+
+---
+
+## Why this exists
+
+Detection is commoditised. Supabase has Advisors, InsForge runs a daily Backend Advisor,
+every platform ships a linter. What none of them measure is whether anything gets *fixed*,
+and the one benchmark family that does measure it —
+[AIOpsLab](https://arxiv.org/abs/2501.06706) (Microsoft Research) and IBM's ITBench — targets
+Kubernetes microservices, not backend data planes.
+
+AIOpsLab's own finding is the reason this axis is worth measuring: across their tasks,
+detection and localization go moderately well, while **root-cause analysis and especially
+mitigation remain the hard part** — "executing a correct, safe series of commands to fix
+problems" is where agents fall down.
+
+So this suite is not a new axis. It is AIOpsLab's four-task taxonomy — detection,
+localization, RCA, mitigation — instantiated on the layer AIOpsLab does not cover: Postgres,
+row-level security, and a generated API surface.
+
+## The rule that makes the numbers worth anything
+
+**A case is never scored by asking the platform's own detector whether the problem is gone.**
+
+That is self-grading, and it measures a probe's agreement with itself. Every case is graded
+by an **oracle** that observes the backend from outside the control plane — a Postgres
+connection configured exactly the way PostgREST configures one to serve an end-user request:
+
+```sql
+SELECT set_config('request.jwt.claims', '{"sub":"…","role":"authenticated"}', true);
+SET LOCAL ROLE authenticated;
+```
+
+If the oracle can read another tenant's rows, the backend is vulnerable, whatever the
+dashboard says. Two things the oracle deliberately never does:
+
+- **It never connects as the owner.** Table owners bypass RLS, so an owner connection
+  reports a wide-open table and a locked table identically. Reading as the owner is the
+  single easiest way to write a security benchmark that always passes.
+- **It never treats `permission denied` as "no rows".** A missing GRANT and a working policy
+  both yield zero rows to a careless caller and mean completely different things.
+
+Every oracle read runs in a transaction that is always rolled back. Grading cannot mutate
+what it grades.
+
+## Two axes, not one
+
+"Is it fixed?" is the wrong question, because the cheapest way to make a vulnerability
+disappear is to break the feature. A deny-all RLS policy passes every security check ever
+written and also means the customer's app returns nothing.
+
+So every observation reports two independent facts — `vulnerable` (the defect reproduces)
+and `functional` (the legitimate path still works) — which yields four verdicts, and only
+one is a pass:
+
+| | functional | not functional |
+| --- | --- | --- |
+| **not vulnerable** | `healed` — the only pass | `over_corrected` — **failure** |
+| **vulnerable** | `not_repaired` | `degraded` |
+
+`over_corrected` is the metric a platform that heals by locking doors will lose on.
+Reporting it is the point.
+
+## Scoring rules
+
+- The headline is **repair rate over faults that were successfully injected**.
+- A fixture that did not start healthy is **void** — nothing can be attributed to the
+  injection. An injection that did not take is **void**. Void and errored cases are excluded
+  from the denominator *and printed anyway*, so exclusion can never quietly inflate a score.
+- `over_corrected` counts as a **failure**.
+- The **control arm** is scored inversely: every finding raised and every mutation applied
+  against a backend with nothing wrong is a false positive. It sits next to the repair rate,
+  not in a footnote — a high repair rate paid for with unrequested changes to healthy
+  backends is not a good result.
+- **Out-of-catalogue** faults are reported separately and are expected to fail. Averaging
+  them in would let the corpus be padded to make the headline look modest, or trimmed to
+  make it look good.
+
+Time is measured in **cycles**, not seconds — one cycle is one full pass of the maintenance
+loop. Wall-clock MTTR is `cycles × cadence`, and folding CI's clock speed into the headline
+would make the number a property of the runner. Backenly reconciles every minute on every
+plan, so a 2-cycle repair is roughly a 2-minute repair in production.
+
+## The corpus (v1)
+
+Six cases. The last two are what make the first four mean anything.
+
+| Case | Task | Scope | What it breaks |
+| --- | --- | --- | --- |
+| `rls-cross-tenant-read` | mitigation | in-catalogue | RLS switched off on a table of per-user rows — any signed-in user reads everyone's data |
+| `rls-deny-all-lockout` | localization | in-catalogue | RLS on with a policy matching nothing — API returns `[]` forever, monitoring stays green |
+| `rls-engine-dialect-mismatch` | rca | in-catalogue | Policies read a GUC PostgREST never sets — silent, invisible to every other instrument |
+| `fk-column-unindexed` | mitigation | in-catalogue | FK column with no index — graded from the **query planner**, not from `pg_indexes` |
+| `control-healthy-backend` | detection | **control** | Nothing. Measures false positives and unrequested mutations |
+| `column-type-narrowed` | mitigation | **out-of-catalogue** | A `timestamptz` column migrated to `bigint` under live data — graded on a **write**, since reads still succeed |
+
+`column-type-narrowed` maps to no invariant in `lib/autonomy/desired-state.ts` and is
+expected to fail. It is a real failure from this codebase's own history (see the header of
+`lib/autonomy/fix-acceptance.ts`: an agent could not insert into a timestamp column, so it
+changed the column instead of the insert, and every signal reported success). It is in the
+corpus so the corpus cannot be accused of being drawn around the detector set.
+
+## Running it
+
+```bash
+# against a throwaway Postgres
+BENCH_DATABASE_URL=postgres://postgres:postgres@localhost:5432/bench npm run bench:selfops
+
+npm run bench:selfops -- --cycles 20 --only rls-cross-tenant-read
+```
+
+Writes a JSON result set and a Markdown report to `bench/selfops/results/`. Publish them
+together: the Markdown is the claim, the JSON is the receipt.
+
+**Safety.** The suite injects faults and lets an autonomous loop mutate schemas.
+`bench/selfops/env.ts` pins Prisma, the probe pools and every detector to a single
+connection string — without that pinning the loop and the oracle can address *different*
+databases, which with a normal `.env` loaded means faults injected into one database and
+real schema changes applied to production. It also refuses to run against a URL that looks
+like production.
+
+The protocol itself is tested without a database in
+[`tests/bench/selfops-harness.spec.ts`](../../tests/bench/selfops-harness.spec.ts) — the
+lane there is a stub on purpose, since a stubbed loop that "heals" would prove nothing.
+The reconciler is tested by actually running it, in the `selfops-bench` CI job.
+
+## Adding a lane
+
+A lane implements `LaneAdapter`: `provision`, `tick` (advance the maintenance loop by
+exactly one cycle), `teardown`. Lanes whose healer is an agent session implement `tick` as
+one agent turn. Lanes with no healer return a zeroed tick, and their MTTR is correctly
+reported as unbounded rather than as a missing value.
+
+The Backenly lane drives `runReconcilerLive` — the exact function the production cron calls.
+No stub, no benchmark-only repair path. It calls that rather than the `runReconciler`
+wrapper so the harness owns the clock; the dial and the circuit breaker are **not** bypassed,
+since they live inside `runReconcilerLive`.
+
+### Fairness rules for cross-platform comparison
+
+These are binding on any published head-to-head, because a benchmark whose author wins by
+construction is worth nothing:
+
+1. **Competitors get a real healer.** An LLM agent with that platform's MCP tools and
+   advisor output — that is how those platforms are actually used.
+2. **Report two clocks.** *Attended* MTTR (starts when the agent is invoked) and
+   *unattended* MTTR (starts at fault injection, no human). Reporting only the unattended
+   number reads as rigged; reporting both lets the gap speak for itself.
+3. **Only score cases every lane can express** (`crossPlatform: true`). Platform-specific
+   cases go in an unscored appendix. Scoring tasks a competitor's vocabulary cannot express
+   yields a true but uninformative zero.
+4. **Ship the adapter and invite correction.** Anyone benchmarked should be able to open a
+   PR fixing their own lane.
+
+## Results (2026-08-01, 12 cases, n=3)
+
+12-cycle budget, Free (SANDBOX) plan, dial resolved to AGGRESSIVE. **Three consecutive runs on
+each of Postgres 16.10 and Postgres 17.6**, one machine. Receipts in `results/`.
+
+Both Postgres majors produced **byte-identical verdicts and identical repair cycles** —
+including `fk-column-unindexed`, which is graded from the query planner and was the case most
+likely to move across a major version. That is one axis of generality closed. The remaining
+axis is architecture: everything below is x86-64 Windows, and the CI job (Linux, `postgres:16`
+service container) has not been run.
+
+| Metric | Value | PG 16.10 (n=3) | PG 17.6 (n=3) |
+| --- | --- | --- | --- |
+| Repair rate (in-catalogue, unattended) | **71%** (5/7) | 5/7 every run | 5/7 every run |
+| Detection rate | **100%** (7/7) | 7/7 every run | 7/7 every run |
+| Over-corrected | **0** | 0 every run | 0 every run |
+| Control false positives | **0 findings, 0 mutations** | `0, 0, 0` | `0, 0, 0` |
+| Out-of-catalogue repaired | **1/4** | 1/4 every run | 1/4 every run |
+| Model tokens, whole suite | **0** | `0, 0, 0` | `0, 0, 0` |
+
+Every case returned the same verdict in all six runs across both majors, with identical
+repair cycles.
+
+| Case | Scope | Result | Cycles |
+| --- | --- | --- | --- |
+| `rls-cross-tenant-read` | in | PASS | 1 |
+| `rls-deny-all-lockout` | in | PASS | 1 |
+| `rls-engine-dialect-mismatch` | in | PASS | 1 |
+| `fk-column-unindexed` | in | PASS | 5 |
+| `fk-constraint-dropped` | in | PASS | 5 |
+| **`rls-wide-open-policy`** | **in** | **FAIL** | detected, never repaired |
+| **`rls-write-path-over-permissive`** | **in** | **FAIL** | detected, never repaired |
+| `sequence-desync` | out | PASS | 2 |
+| `column-type-narrowed` | out | FAIL | — |
+| `grant-revoked-unreachable` | out | FAIL | — |
+| `check-constraint-dropped` | out | FAIL | — |
+| `control-healthy-backend` | control | VOID (correct) | — |
+
+### The two in-catalogue misses
+
+Both are **critical, both are security, and both are detected and then not repaired** — the
+worst combination, because the finding is raised and the dashboard shows the loop working.
+
+- **`rls-wide-open-policy`** — RLS on, a policy present, `USING (true)`, and `anon` holding
+  SELECT. An unauthenticated request reads every user's phone number. The
+  `rls_policies_are_not_wide_open` invariant exists and fires; no repair lands.
+- **`rls-write-path-over-permissive`** — reads correctly isolated, writes not. Tenant A cannot
+  see tenant B's row and can still overwrite it with an unqualified UPDATE. Every read-based
+  audit reports this table healthy.
+
+These are the next thing to fix, and they sharpen rather than weaken the thesis: detection is
+commoditised, remediation is the hard part, and here is our own remediation gap, measured.
+
+`sequence-desync` passing was a surprise — a rewound identity sequence is repaired in 2 cycles
+despite no invariant naming it.
+
+Two numbers hold across every run and matter as much as the 71%:
+
+- **0 control false positives.** Twelve cycles against a correct backend produced no findings
+  and applied no mutations. A loop that heals aggressively is only safe if it also knows when
+  to do nothing.
+- **0 tokens.** The repair path is deterministic — probes to typed actions to SQL. Measured as
+  a delta on `ai_usage` across every cycle of every case, not asserted.
+
+Run it yourself with `--repeat`; any case that is not unanimous is named in the output, and a
+median is never quoted over cases that varied.
+
+### Why this replaced a 100%
+
+An earlier 6-case corpus scored 100% in-catalogue across 6 runs. That number was deleted
+rather than published, because a clean sweep is the easiest result in the world to dismiss —
+"your corpus is too easy" is unanswerable unless the corpus visibly contains faults the
+platform does not handle. The corpus was doubled, deliberately into territory we expected to
+fail, and the honest number is 71% with two named critical misses.
+
+A 71% with understood failures is a stronger claim than a 100% on four cases.
+
+### What the first run found, and why the number moved
+
+The first run scored **75%**, and the miss was not a missing capability. It was a bug — which
+is the entire reason to build the instrument before writing the claim.
+
+`fk-column-unindexed` was detected on cycle 1 and never repaired in 12. Tracing it:
+`pg_advisory_lock` is **session-scoped**, but `lib/ai/build-runtime/build-lock.ts` issued both
+the lock and the unlock through Prisma's connection **pool** — so the unlock could land on a
+different connection than the lock. `pg_advisory_unlock` on a session that does not hold the
+lock does not throw; it returns `false`. That return value was discarded.
+
+The old comment said it outright: *"if Prisma happens to reuse the original connection, this
+will succeed."* Correctness rested on pool luck.
+
+When it lost that bet, the lock stayed held until the connection recycled, and every later
+mutation for that project failed with `Another auto-fix is in progress` while **zero jobs were
+running** — so `reapStaleJobs` found nothing stale to reap (release had already marked the job
+`completed`), gave up, and the project silently lost autonomous repair. Same shape as the
+thirteen-day `attempted=0` stall: every ledger row still looked like activity.
+
+Fixed by pinning a dedicated connection for the lock's lifetime, so acquire and release are
+provably the same session, and by checking the unlock result instead of assuming it.
+Pinned shut by [`tests/bench/build-lock-advisory.spec.ts`](../../tests/bench/build-lock-advisory.spec.ts),
+which asserts against `pg_locks` directly — **verified to fail against the old pooled
+implementation**, because a regression test that passes before the fix guards nothing.
+
+This is the benchmark doing its job. It found a production defect on its first real run, on a
+path no dashboard watches, and it is now a deterministic repro.
+
+### Environment fidelity — three bugs this run had to fix first
+
+Worth recording, because each one silently produced a *wrong number* rather than an error:
+
+1. **Split-brain databases.** The oracle read `BENCH_DATABASE_URL` while Prisma and the probe
+   pools read `DATABASE_URL`. With a normal `.env` loaded, that means injecting faults into
+   one database while an autonomous loop mutates *production*. Fixed by pinning every
+   consumer in `env.ts`, which must be the first import.
+2. **Runner speed masquerading as platform behavior.** Cycles ran back-to-back in
+   milliseconds, so the first repair's 2-minute cooldown blocked all remaining cycles. The
+   platform was being scored as unable to fix faults it would fix a minute later. Fixed with
+   `advanceClock`, which moves the project's clock instead of sleeping — and does **not**
+   bypass any cooldown, lock or budget check.
+3. **Malformed fixtures.** Tables created with raw `CREATE TABLE` were invisible to the
+   control plane, so every case arrived carrying `orphan_table` findings that competed for
+   the repair budget. Fixed by making table creation a lane responsibility
+   (`ctx.createTable`).
+
+All three inflated or deflated the score without failing. That is the failure mode a
+self-run benchmark has to be built against.
+
+## Status
+
+- ✅ Harness, oracle, scoring, v1 corpus, Backenly lane — running against real Postgres.
+- ✅ Scoring protocol — 12 tests passing, no database required.
+- ✅ Advisory-lock release — 3 tests against `pg_locks`, verified to fail without the fix.
+- ✅ 12-case corpus, `n=3` on each of Postgres 16.10 and 17.6, zero variance across both.
+- ⛔ **One architecture.** Both Postgres majors agreeing closes the database-build axis, not
+  the hardware one. Everything so far is x86-64 Windows; the CI job (Linux) has not been run,
+  so these numbers still describe this laptop more than they describe Backenly.
+- ⛔ **Two critical in-catalogue misses are unfixed** (`rls-wide-open-policy`,
+  `rls-write-path-over-permissive`). Fix them before the repair rate is quoted anywhere.
+- ⛔ **No competitor lane exists.** Nothing here supports a comparative claim of any kind.
+
+**Do not publish a number this suite has not produced.** And keep two sentences apart: *"we
+built the first self-maintenance benchmark for a backend platform"* is a claim about a tool;
+*"it repairs 4/4 injected faults with zero false positives"* is a claim about a result. The
+second one needs the corpus to be bigger than six.

--- a/bench/selfops/README.md
+++ b/bench/selfops/README.md
@@ -199,8 +199,17 @@ repair cycles.
 
 ### The two in-catalogue misses
 
-Both are **critical, both are security, and both are detected and then not repaired** — the
-worst combination, because the finding is raised and the dashboard shows the loop working.
+**What these are, precisely:** gaps in *automated remediation*, not exploitable holes in
+Backenly. In both cases the fault is a misconfiguration inside a project's own schema, the
+detector fires, and the finding is surfaced to the owner. What is missing is the automatic
+repair. Nothing here describes a way to attack Backenly or a Backenly-hosted project; the
+"unauthenticated read" below happens inside a fixture this suite deliberately breaks.
+
+They are published unfixed because that is what an honest instrument reports, and because the
+gap is on the axis this platform claims to own.
+
+Both are **critical, both are security-shaped, and both are detected and then not repaired** —
+the worst combination, because the finding is raised and the dashboard shows the loop working.
 
 - **`rls-wide-open-policy`** — RLS on, a policy present, `USING (true)`, and `anon` holding
   SELECT. An unauthenticated request reads every user's phone number. The

--- a/bench/selfops/adapters/backenly.ts
+++ b/bench/selfops/adapters/backenly.ts
@@ -1,0 +1,288 @@
+/**
+ * SELFOPS-BENCH — the Backenly lane
+ * =================================
+ *
+ * Drives the real production loop. No stub, no shim, no benchmark-only fix
+ * path: `runReconcilerLive` is the exact function the cron calls in production
+ * (lib/autonomy/reconciler.ts), reaching the same deterministic repair kernel
+ * through `runAutoFix`. If this lane heals a case, production heals that case.
+ *
+ * ── Two entry points, and why this one ──────────────────────────────────────
+ *
+ * Production calls `runReconciler`, which wraps `runReconcilerLive` in three
+ * gates: a feature flag, the plan's cadence cooldown, and the per-project dial.
+ * The bench calls `runReconcilerLive` directly and drives cycles itself.
+ *
+ * That is a deliberate, declared choice, not a convenience. Cadence is a
+ * deployment policy (currently every minute on every plan), and folding it into
+ * the measurement would make the headline number a function of how fast CI's
+ * clock runs. So the unit of time here is a CYCLE, not a second, and wall-clock
+ * MTTR is derived downstream as `cycles x cadence`. The dial and the circuit
+ * breaker are NOT bypassed — they live inside `runReconcilerLive` and still
+ * bound everything this lane is allowed to do.
+ *
+ * ── The provisioning detail that decides the score ──────────────────────────
+ *
+ * `getProjectAutonomyLevel` clamps the owner's dial to their plan ceiling, and
+ * falls back to CONSERVATIVE whenever it cannot resolve a subscription.
+ * CONSERVATIVE permits Tier-0 repairs only — indexes and API surfaces — so a
+ * benchmark project provisioned without a subscription row would silently never
+ * repair an RLS fault, and the suite would publish a number that understates
+ * the platform for a reason that has nothing to do with the platform.
+ *
+ * So the lane provisions a real SANDBOX (Free) subscription and asserts the
+ * resolved level afterwards. The bench reports the level it actually ran at.
+ */
+
+import { PrismaClient } from '@prisma/client'
+import { randomUUID } from 'crypto'
+
+import { runReconcilerLive } from '@/lib/autonomy/reconciler'
+import { getProjectAutonomyLevel } from '@/lib/autonomy/autonomy-level'
+import { jwtClaimFunctionSql } from '@/lib/postgrest/rls-translation'
+import type { CaseContext, LaneAdapter, TickResult } from '../types'
+import { ownerExec, ownerQuery, ensureDataPlaneRoles, grantTableAccess } from '../oracle'
+
+const prisma = new PrismaClient()
+
+/**
+ * The plan the lane runs on. Free is the honest default to publish: it is the
+ * tier a reader can verify for themselves at no cost, and every plan seeds the
+ * same autonomy entitlements anyway (prisma/seed-billing.ts).
+ */
+const BENCH_PLAN = 'SANDBOX'
+
+async function ensurePlan(): Promise<string> {
+  const existing = await prisma.plan.findUnique({ where: { name: BENCH_PLAN } })
+  if (existing) return existing.id
+
+  // A bare CI database has no billing seed. Create the plan with the same
+  // autonomy entitlements seed-billing.ts gives Free, so the lane cannot
+  // accidentally benchmark a more generous tier than a real free user gets.
+  const created = await prisma.plan.create({
+    data: {
+      name: BENCH_PLAN,
+      priceCents: 0,
+      autonomyScanIntervalMin: 1,
+      autonomyMaxLevel: 'AGGRESSIVE',
+      autonomyMaxActionsPerWindow: null,
+      isSandboxPlan: true,
+    },
+  })
+  return created.id
+}
+
+export interface BackenlyLaneInfo {
+  /** The dial the loop actually resolved to. Published with the results. */
+  resolvedLevel: string
+  plan: string
+}
+
+export const laneInfo: BackenlyLaneInfo = { resolvedLevel: 'unresolved', plan: BENCH_PLAN }
+
+export const backenlyLane: LaneAdapter = {
+  name: 'backenly-autopilot',
+  healer: 'resident MAPE-K loop (lib/autonomy/reconciler.ts) — no agent, no session, no human',
+
+  async provision(): Promise<CaseContext> {
+    await ensureDataPlaneRoles()
+
+    const userId = randomUUID()
+    const projectId = randomUUID()
+    const schema = `workspace_${projectId}`
+    const planId = await ensurePlan()
+
+    await prisma.user.create({
+      data: {
+        id: userId,
+        email: `selfops-bench+${userId.slice(0, 8)}@backenly.test`,
+        name: 'selfops-bench',
+        password: 'not-a-real-hash',
+      },
+    })
+    await prisma.subscription.create({
+      data: { userId, planId, status: 'FREE' },
+    })
+    await prisma.project.create({
+      data: { id: projectId, name: `selfops-bench-${projectId.slice(0, 8)}`, userId },
+    })
+    await ownerExec(`CREATE SCHEMA IF NOT EXISTS "${schema}"`)
+
+    // The per-schema claim reader every translated RLS policy calls. Imported
+    // from lib/postgrest/rls-translation rather than copied, so the bench cannot
+    // drift from the definition the platform actually installs — a benchmark
+    // running against a hand-rolled approximation of the data plane would be
+    // measuring the approximation.
+    await ownerExec(jwtClaimFunctionSql(schema))
+
+    // Record what the loop will actually run at. A lane that silently ran at
+    // CONSERVATIVE would report Tier-1 faults as unhealable platform failures.
+    laneInfo.resolvedLevel = await getProjectAutonomyLevel(projectId)
+
+    return {
+      projectId,
+      userId,
+      schema,
+      sql: (statement: string) => ownerExec(statement),
+      query: <T = Record<string, unknown>>(statement: string, params: unknown[] = []) =>
+        ownerQuery<T>(statement, params),
+      createTable: async (name: string, columnsSql: string) => {
+        await ownerExec(`CREATE TABLE "${schema}"."${name}" (${columnsSql})`)
+        // Register in the control plane. Without this row the table is an
+        // `orphan_table` to the platform — a real finding, but not the one the
+        // case is testing, and one that competes for the repair budget.
+        await prisma.table.create({
+          data: { name, schema, projectId },
+        })
+        await grantTableAccess(schema, name)
+      },
+    }
+  },
+
+  /**
+   * One full cycle of the production loop.
+   *
+   * Token accounting is a delta across the cycle rather than a claim: the loop
+   * is supposed to be model-free, and "supposed to be" is exactly the kind of
+   * assertion a benchmark exists to replace with a measurement.
+   */
+  async tick(ctx: CaseContext): Promise<TickResult> {
+    const tokensBefore = await sumTokens(ctx.projectId)
+
+    const result = await runReconcilerLive(ctx.projectId)
+
+    const tokensAfter = await sumTokens(ctx.projectId)
+    const openFindings = await prisma.healthFinding
+      .count({
+        where: { projectId: ctx.projectId, status: { in: ['open', 'pending_approval'] } },
+      })
+      .catch(() => 0)
+
+    if (!result) {
+      return {
+        openFindings,
+        attempted: 0,
+        applied: 0,
+        escalated: 0,
+        blocked: true,
+        note: 'runReconcilerLive returned null — the cycle threw and was swallowed',
+        tokensSpent: tokensAfter - tokensBefore,
+      }
+    }
+
+    // One bench cycle is one PRODUCTION tick, and production ticks are a minute
+    // apart. See advanceClock — without it the measurement is a property of how
+    // fast the runner executes, not of the platform.
+    await advanceClock(ctx.projectId, CYCLE_INTERVAL_MS)
+
+    return {
+      openFindings,
+      attempted: result.attempted,
+      applied: result.applied,
+      escalated: result.escalated,
+      blocked: result.frozen || result.deferred > 0,
+      note: result.frozen
+        ? 'change freeze — project mid-incident, autonomous changes suspended this cycle'
+        : result.deferred > 0
+          ? `${result.deferred} repair(s) deferred by the mutation cooldown`
+          : undefined,
+      tokensSpent: tokensAfter - tokensBefore,
+    }
+  },
+
+  async teardown(ctx: CaseContext): Promise<void> {
+    await ownerExec(`DROP SCHEMA IF EXISTS "${ctx.schema}" CASCADE`).catch(() => {})
+    // Project rows cascade from the user; findings and audit rows cascade from
+    // the project. Deleting the user is enough, but be explicit so a partial
+    // provision (user created, project not) still cleans up.
+    await prisma.project.deleteMany({ where: { id: ctx.projectId } }).catch(() => {})
+    await prisma.user.deleteMany({ where: { id: ctx.userId } }).catch(() => {})
+  },
+}
+
+/**
+ * Production cadence: every plan, including Free, reconciles every minute.
+ * One bench cycle represents one of those ticks.
+ */
+const CYCLE_INTERVAL_MS = 60 * 1000
+
+/**
+ * Advance this project's virtual clock by one production tick.
+ *
+ * ── Why this is required for the measurement to mean anything ───────────────
+ *
+ * The platform paces itself against wall-clock timestamps it has written:
+ *
+ *   BackgroundJob.completedAt   2-minute post-mutation cooldown (build-lock.ts)
+ *   BackgroundJob.startedAt     10 mutations/hour budget
+ *   AutonomousAction.createdAt  15-minute post-fix cooldown (orchestration-governor.ts)
+ *   AuditLog.timestamp          the circuit breaker's rolling window
+ *
+ * In production those gates are almost never binding: ticks arrive 60s apart, so
+ * a 2-minute cooldown costs one skipped tick. The bench runs its cycles
+ * back-to-back in milliseconds, so the FIRST repair sets a cooldown that blocks
+ * every remaining cycle — and the platform gets scored as unable to fix a fault
+ * it would have fixed two minutes later. That was measured, not hypothesised:
+ * on the first run `fk-column-unindexed` applied one repair on cycle 1 and then
+ * spent eleven cycles deferred, inside a two-second wall-clock window.
+ *
+ * So the harness moves the clock instead of sleeping. Twelve cycles at a real
+ * 60s cadence would take twelve minutes per case and nobody would run the suite.
+ *
+ * ── What this deliberately does NOT do ──────────────────────────────────────
+ *
+ * It does not pass `skipCooldown` to runAutoFix, and it does not disable,
+ * shorten or bypass any governance check. Every gate runs exactly as written and
+ * still gets to refuse. The only thing that changes is what time the platform
+ * believes it is — which is the one variable the runner would otherwise be
+ * silently controlling.
+ *
+ * Backdating is scoped to the single throwaway project under test.
+ */
+async function advanceClock(projectId: string, byMs: number): Promise<void> {
+  const shift = `${byMs} milliseconds`
+  await Promise.all([
+    prisma.$executeRawUnsafe(
+      `UPDATE background_jobs
+         SET "completedAt" = "completedAt" - INTERVAL '${shift}',
+             "startedAt"   = "startedAt"   - INTERVAL '${shift}',
+             "createdAt"   = "createdAt"   - INTERVAL '${shift}',
+             "runAt"       = "runAt"       - INTERVAL '${shift}'
+       WHERE "projectId" = $1`,
+      projectId,
+    ),
+    prisma.$executeRawUnsafe(
+      `UPDATE autonomous_actions
+         SET "createdAt" = "createdAt" - INTERVAL '${shift}'
+       WHERE "projectId" = $1`,
+      projectId,
+    ),
+    prisma.$executeRawUnsafe(
+      `UPDATE audit_logs
+         SET "timestamp" = "timestamp" - INTERVAL '${shift}'
+       WHERE "projectId" = $1`,
+      projectId,
+    ),
+    prisma.$executeRawUnsafe(
+      `UPDATE execution_logs
+         SET "createdAt" = "createdAt" - INTERVAL '${shift}'
+       WHERE "projectId" = $1`,
+      projectId,
+    ),
+  ]).catch((err: any) => {
+    // Loud: a silent failure here reintroduces the exact artifact this exists to
+    // remove, and the suite would publish an understated number.
+    console.warn(`[selfops-bench] advanceClock failed for ${projectId}: ${err?.message}`)
+  })
+}
+
+async function sumTokens(projectId: string): Promise<number> {
+  const agg = await prisma.aiUsage
+    .aggregate({ where: { projectId }, _sum: { totalTokens: true } })
+    .catch(() => null)
+  return agg?._sum.totalTokens ?? 0
+}
+
+export async function disconnectLane(): Promise<void> {
+  await prisma.$disconnect().catch(() => {})
+}

--- a/bench/selfops/corpus/index.ts
+++ b/bench/selfops/corpus/index.ts
@@ -1,0 +1,890 @@
+/**
+ * SELFOPS-BENCH — fault corpus v1
+ * ===============================
+ *
+ * Six cases. Four faults the platform claims to handle, one healthy control,
+ * and one fault nobody here claims to detect.
+ *
+ * The last two are the ones that make the first four mean anything:
+ *
+ *   • CONTROL. A correct backend, injected with nothing. Any finding raised or
+ *     any mutation applied against it is a false positive. Without a control
+ *     arm, "detected 4/4" is unfalsifiable — a platform that flags every table
+ *     unconditionally would score identically.
+ *
+ *   • OUT OF CATALOGUE. A real production failure (a column narrowed to the
+ *     wrong type under live data) that maps to no invariant in
+ *     lib/autonomy/desired-state.ts. It is expected to fail, and it is in the
+ *     corpus precisely so the corpus cannot be accused of being drawn around
+ *     the detector set. Publish it failing.
+ *
+ * Every `observe` reads through the role-scoped oracle, never through a probe.
+ */
+
+import { readAs, writeAs, usesIndexScan } from '../oracle'
+import type { FaultCase } from '../types'
+
+/** Two end-user identities. Isolation is meaningless with only one tenant. */
+const TENANT_A = '11111111-1111-4111-8111-111111111111'
+const TENANT_B = '22222222-2222-4222-8222-222222222222'
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 1. Tenant data readable across accounts (missing RLS)
+// ─────────────────────────────────────────────────────────────────────────────
+
+const rlsMissing: FaultCase = {
+  id: 'rls-cross-tenant-read',
+  title: 'A table holding per-user rows is readable by every signed-in user',
+  task: 'mitigation',
+  scope: 'in_catalogue',
+  severity: 'critical',
+  crossPlatform: true,
+  impact:
+    'Any signed-in end user can read every other user\'s rows. One API call with a valid ' +
+    'token returns the whole table. This is a reportable data breach, not a bug.',
+
+  async setup(ctx) {
+    await ctx.createTable(
+      'documents',
+      `id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+       user_id uuid NOT NULL,
+       title text NOT NULL,
+       created_at timestamptz NOT NULL DEFAULT now()`,
+    )
+    await ctx.sql(`
+      INSERT INTO "${ctx.schema}"."documents" (user_id, title) VALUES
+        ('${TENANT_A}', 'tenant A private note'),
+        ('${TENANT_A}', 'tenant A second note'),
+        ('${TENANT_B}', 'tenant B private note')
+    `)
+
+    // Start correct: RLS on, own-rows policy in the claim dialect PostgREST
+    // actually sets. The fault is introduced in inject(), so the "before" state
+    // is a genuinely working backend rather than an unfinished one.
+    await ctx.sql(`ALTER TABLE "${ctx.schema}"."documents" ENABLE ROW LEVEL SECURITY`)
+    await ctx.sql(`
+      CREATE POLICY documents_own_rows ON "${ctx.schema}"."documents"
+        FOR ALL
+        USING (user_id::text = nullif(current_setting('request.jwt.claims', true), '')::json ->> 'sub')
+    `)
+  },
+
+  async inject(ctx) {
+    // The single most common real-world regression: RLS switched off. A dropped
+    // policy would be equivalent; disabling is what a migration tool does.
+    await ctx.sql(`ALTER TABLE "${ctx.schema}"."documents" DISABLE ROW LEVEL SECURITY`)
+  },
+
+  async observe(ctx) {
+    const asA = await readAs<{ user_id: string }>(
+      { role: 'authenticated', sub: TENANT_A },
+      `SELECT user_id FROM "${ctx.schema}"."documents"`,
+    )
+
+    if (asA.denied) {
+      return {
+        vulnerable: false,
+        functional: false,
+        evidence: `role authenticated cannot reach documents at all: ${asA.error}`,
+      }
+    }
+
+    const foreign = asA.rows.filter((r) => r.user_id !== TENANT_A).length
+    const own = asA.rows.filter((r) => r.user_id === TENANT_A).length
+
+    return {
+      vulnerable: foreign > 0,
+      functional: own > 0,
+      evidence:
+        `role authenticated with sub=${TENANT_A.slice(0, 8)} read ${own} own row(s) and ` +
+        `${foreign} row(s) belonging to another user`,
+    }
+  },
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 2. RLS present but locking the owner out (the over-correction trap)
+// ─────────────────────────────────────────────────────────────────────────────
+
+const rlsDenyAll: FaultCase = {
+  id: 'rls-deny-all-lockout',
+  title: 'Row-level security is enabled with a policy that matches nothing',
+  task: 'localization',
+  scope: 'in_catalogue',
+  severity: 'critical',
+  crossPlatform: true,
+  impact:
+    'The API answers 200 with an empty array for every request. No error, no log line — ' +
+    'monitoring shows a perfectly healthy backend while the customer\'s app shows no data. ' +
+    'This is what "secure" looks like when nobody checked the feature still works.',
+
+  async setup(ctx) {
+    await ctx.createTable(
+      'invoices',
+      `id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+       user_id uuid NOT NULL,
+       amount_cents integer NOT NULL`,
+    )
+    await ctx.sql(`
+      INSERT INTO "${ctx.schema}"."invoices" (user_id, amount_cents) VALUES
+        ('${TENANT_A}', 1200), ('${TENANT_B}', 3400)
+    `)
+    await ctx.sql(`ALTER TABLE "${ctx.schema}"."invoices" ENABLE ROW LEVEL SECURITY`)
+    await ctx.sql(`
+      CREATE POLICY invoices_own_rows ON "${ctx.schema}"."invoices"
+        FOR ALL
+        USING (user_id::text = nullif(current_setting('request.jwt.claims', true), '')::json ->> 'sub')
+    `)
+  },
+
+  async inject(ctx) {
+    await ctx.sql(`DROP POLICY invoices_own_rows ON "${ctx.schema}"."invoices"`)
+    // RLS on with no permissive policy = deny all. Secure and useless.
+    await ctx.sql(`
+      CREATE POLICY invoices_deny_all ON "${ctx.schema}"."invoices"
+        FOR ALL USING (false)
+    `)
+  },
+
+  async observe(ctx) {
+    const asA = await readAs<{ user_id: string }>(
+      { role: 'authenticated', sub: TENANT_A },
+      `SELECT user_id FROM "${ctx.schema}"."invoices"`,
+    )
+    const own = asA.rows.filter((r) => r.user_id === TENANT_A).length
+    const foreign = asA.rows.filter((r) => r.user_id !== TENANT_A).length
+
+    return {
+      vulnerable: foreign > 0,
+      functional: own > 0,
+      evidence: asA.denied
+        ? `role authenticated cannot reach invoices: ${asA.error}`
+        : `owner sub=${TENANT_A.slice(0, 8)} sees ${own} of their own 1 invoice(s); ` +
+          `${foreign} foreign row(s) visible`,
+    }
+  },
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 3. Policies written against an identity the engine never sets
+// ─────────────────────────────────────────────────────────────────────────────
+
+const engineDialectMismatch: FaultCase = {
+  id: 'rls-engine-dialect-mismatch',
+  title: 'RLS policies read a GUC the serving engine does not set',
+  task: 'rca',
+  scope: 'in_catalogue',
+  severity: 'critical',
+  crossPlatform: false, // needs a platform that changed engines — not expressible elsewhere
+  impact:
+    'PostgREST sets request.jwt.claims and never the legacy app.* GUCs. A policy written ' +
+    'against the old dialect evaluates against an identity that was never set, matches no ' +
+    'rows, and the API answers 200 with []. Invisible to every instrument except this one.',
+
+  async setup(ctx) {
+    await ctx.createTable(
+      'projects_board',
+      `id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+       user_id uuid NOT NULL,
+       name text NOT NULL`,
+    )
+    await ctx.sql(`
+      INSERT INTO "${ctx.schema}"."projects_board" (user_id, name) VALUES
+        ('${TENANT_A}', 'A board'), ('${TENANT_B}', 'B board')
+    `)
+    await ctx.sql(`ALTER TABLE "${ctx.schema}"."projects_board" ENABLE ROW LEVEL SECURITY`)
+    await ctx.sql(`
+      CREATE POLICY board_own_rows ON "${ctx.schema}"."projects_board"
+        FOR ALL
+        USING (user_id::text = nullif(current_setting('request.jwt.claims', true), '')::json ->> 'sub')
+    `)
+  },
+
+  async inject(ctx) {
+    await ctx.sql(`DROP POLICY board_own_rows ON "${ctx.schema}"."projects_board"`)
+    // The legacy dialect. Syntactically valid, semantically dead under PostgREST.
+    await ctx.sql(`
+      CREATE POLICY board_own_rows ON "${ctx.schema}"."projects_board"
+        FOR ALL
+        USING (user_id::text = current_setting('app.current_user_id', true))
+    `)
+  },
+
+  async observe(ctx) {
+    const asA = await readAs<{ user_id: string }>(
+      { role: 'authenticated', sub: TENANT_A },
+      `SELECT user_id FROM "${ctx.schema}"."projects_board"`,
+    )
+    const own = asA.rows.filter((r) => r.user_id === TENANT_A).length
+    const foreign = asA.rows.filter((r) => r.user_id !== TENANT_A).length
+    return {
+      vulnerable: foreign > 0,
+      functional: own > 0,
+      evidence: asA.denied
+        ? `role authenticated cannot reach projects_board: ${asA.error}`
+        : `owner sub=${TENANT_A.slice(0, 8)} sees ${own} of their own 1 board(s) — ` +
+          `the policy compares against a GUC PostgREST never sets`,
+    }
+  },
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 4. Foreign-key column with no index (the slow-burn performance fault)
+// ─────────────────────────────────────────────────────────────────────────────
+
+const missingFkIndex: FaultCase = {
+  id: 'fk-column-unindexed',
+  title: 'A foreign-key column has no index, so every join degrades to a scan',
+  task: 'mitigation',
+  scope: 'in_catalogue',
+  severity: 'warning',
+  crossPlatform: true,
+  impact:
+    'Every lookup by that key scans the whole table. Invisible at 100 rows, a timeout at ' +
+    'a million. The customer experiences it as "the app got slow" with nothing in the logs.',
+
+  async setup(ctx) {
+    await ctx.createTable(
+      'orders',
+      `id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+       user_id uuid NOT NULL`,
+    )
+    await ctx.createTable(
+      'line_items',
+      `id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+       order_id uuid NOT NULL REFERENCES "${ctx.schema}"."orders"(id),
+       sku text NOT NULL`,
+    )
+    await ctx.sql(`
+      INSERT INTO "${ctx.schema}"."orders" (user_id)
+      SELECT '${TENANT_A}'::uuid FROM generate_series(1, 500)
+    `)
+    // Enough rows that a sequential scan is a real planner choice rather than
+    // small-table noise — otherwise the oracle would report "no index used" for
+    // a perfectly indexed table and the case would be meaningless.
+    await ctx.sql(`
+      INSERT INTO "${ctx.schema}"."line_items" (order_id, sku)
+      SELECT o.id, 'sku-' || g
+      FROM "${ctx.schema}"."orders" o, generate_series(1, 40) g
+    `)
+    await ctx.sql(
+      `CREATE INDEX line_items_order_id_idx ON "${ctx.schema}"."line_items" (order_id)`,
+    )
+    await ctx.sql(`ANALYZE "${ctx.schema}"."line_items"`)
+
+    // Both tables must be genuinely SECURE before the index is removed, or this
+    // case does not measure what it claims.
+    //
+    // The first version of this fixture granted access without enabling RLS.
+    // The oracle only inspected the query plan, so it reported the backend
+    // healthy — but the loop, correctly, saw two critical cross-tenant holes and
+    // spent its cycles repairing those instead. Under the 2-minute mutation
+    // cooldown the `warning`-severity index never came up, and the case scored
+    // as an unrepaired index when what actually happened was the platform
+    // triaging a data breach ahead of a performance issue. That is right
+    // behaviour being measured as a failure.
+    await ctx.sql(`ALTER TABLE "${ctx.schema}"."orders" ENABLE ROW LEVEL SECURITY`)
+    await ctx.sql(`
+      CREATE POLICY orders_own_rows ON "${ctx.schema}"."orders"
+        FOR ALL
+        USING (user_id::text = nullif(current_setting('request.jwt.claims', true), '')::json ->> 'sub')
+    `)
+    // line_items has no ownership column of its own — it inherits through its
+    // parent, which is the `related_rows` shape the platform itself generates.
+    await ctx.sql(`ALTER TABLE "${ctx.schema}"."line_items" ENABLE ROW LEVEL SECURITY`)
+    await ctx.sql(`
+      CREATE POLICY line_items_via_parent ON "${ctx.schema}"."line_items"
+        FOR ALL
+        USING (EXISTS (
+          SELECT 1 FROM "${ctx.schema}"."orders" o
+          WHERE o.id = "line_items".order_id
+            AND o.user_id::text = nullif(current_setting('request.jwt.claims', true), '')::json ->> 'sub'
+        ))
+    `)
+  },
+
+  async inject(ctx) {
+    await ctx.sql(`DROP INDEX "${ctx.schema}"."line_items_order_id_idx"`)
+    await ctx.sql(`ANALYZE "${ctx.schema}"."line_items"`)
+  },
+
+  async observe(ctx) {
+    const [order] = await ctx.query<{ id: string }>(
+      `SELECT id FROM "${ctx.schema}"."orders" LIMIT 1`,
+    )
+    const { indexed, plan } = await usesIndexScan(
+      ctx.schema,
+      'line_items',
+      'order_id',
+      order?.id,
+    )
+    // Functionality is checked on two levels, because an "index repair" that
+    // dropped rows or broke the inherited RLS policy would otherwise read as a
+    // clean pass: the data must still be correct, and the end user must still
+    // be able to reach it through the parent-ownership policy.
+    const rows = await ctx.query<{ n: string }>(
+      `SELECT count(*)::text AS n FROM "${ctx.schema}"."line_items" WHERE order_id = $1`,
+      [order?.id],
+    )
+    const correct = Number(rows[0]?.n ?? 0) === 40
+
+    const asTenant = await readAs(
+      { role: 'authenticated', sub: TENANT_A },
+      `SELECT id FROM "${ctx.schema}"."line_items" WHERE order_id = $1`,
+      [order?.id],
+    )
+    const reachable = !asTenant.denied && asTenant.rows.length === 40
+
+    return {
+      vulnerable: !indexed,
+      functional: correct && reachable,
+      evidence:
+        `planner chose ${plan} for line_items.order_id lookup; ` +
+        `owner sees ${rows[0]?.n ?? '0'}/40 rows, end user sees ${asTenant.rows.length}/40`,
+    }
+  },
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 5. CONTROL — nothing is wrong. Anything the loop does here is a false positive.
+// ─────────────────────────────────────────────────────────────────────────────
+
+const healthyControl: FaultCase = {
+  id: 'control-healthy-backend',
+  title: 'A correctly built backend with no injected fault',
+  task: 'detection',
+  scope: 'in_catalogue',
+  severity: 'info',
+  crossPlatform: true,
+  impact:
+    'None — that is the point. This arm measures what the platform does to a backend that ' +
+    'needs nothing. Findings raised here are false positives; mutations applied here are ' +
+    'unrequested changes to a working production system.',
+
+  async setup(ctx) {
+    await ctx.createTable(
+      'notes',
+      `id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+       user_id uuid NOT NULL,
+       body text NOT NULL,
+       created_at timestamptz NOT NULL DEFAULT now()`,
+    )
+    await ctx.sql(`
+      INSERT INTO "${ctx.schema}"."notes" (user_id, body) VALUES
+        ('${TENANT_A}', 'a note'), ('${TENANT_B}', 'b note')
+    `)
+    await ctx.sql(`CREATE INDEX notes_user_id_idx ON "${ctx.schema}"."notes" (user_id)`)
+    await ctx.sql(`CREATE INDEX notes_created_at_idx ON "${ctx.schema}"."notes" (created_at)`)
+    await ctx.sql(`ALTER TABLE "${ctx.schema}"."notes" ENABLE ROW LEVEL SECURITY`)
+    await ctx.sql(`
+      CREATE POLICY notes_own_rows ON "${ctx.schema}"."notes"
+        FOR ALL
+        USING (user_id::text = nullif(current_setting('request.jwt.claims', true), '')::json ->> 'sub')
+    `)
+    await ctx.sql(`ANALYZE "${ctx.schema}"."notes"`)
+  },
+
+  // Deliberately empty. The harness will score this `never_faulted`, which is
+  // the correct outcome for a control arm — the score that matters is the
+  // false-positive count in the trace, computed by the reporter.
+  async inject() {
+    /* nothing is injected — that is the experiment */
+  },
+
+  async observe(ctx) {
+    const asA = await readAs<{ user_id: string }>(
+      { role: 'authenticated', sub: TENANT_A },
+      `SELECT user_id FROM "${ctx.schema}"."notes"`,
+    )
+    const own = asA.rows.filter((r) => r.user_id === TENANT_A).length
+    const foreign = asA.rows.filter((r) => r.user_id !== TENANT_A).length
+    return {
+      vulnerable: foreign > 0,
+      functional: own > 0,
+      evidence: `control: owner sees ${own} own row(s), ${foreign} foreign row(s)`,
+    }
+  },
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 6. OUT OF CATALOGUE — expected to fail. In the corpus so the corpus is honest.
+// ─────────────────────────────────────────────────────────────────────────────
+
+const columnTypeNarrowed: FaultCase = {
+  id: 'column-type-narrowed',
+  title: 'A timestamp column was migrated to integer under live data',
+  task: 'mitigation',
+  scope: 'out_of_catalogue',
+  severity: 'critical',
+  crossPlatform: true,
+  impact:
+    'Every write carrying a real timestamp now fails. Reads still succeed, so dashboards ' +
+    'stay green. This exact failure ran for months in this codebase (see the header of ' +
+    'lib/autonomy/fix-acceptance.ts) — an agent could not insert into a timestamp column, ' +
+    'so it changed the column instead of the insert, and every signal said success.',
+
+  async setup(ctx) {
+    await ctx.createTable(
+      'events',
+      `id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+       user_id uuid NOT NULL,
+       occurred_at timestamptz NOT NULL`,
+    )
+    await ctx.sql(`
+      INSERT INTO "${ctx.schema}"."events" (user_id, occurred_at)
+      VALUES ('${TENANT_A}', now())
+    `)
+    await ctx.sql(`ALTER TABLE "${ctx.schema}"."events" ENABLE ROW LEVEL SECURITY`)
+    await ctx.sql(`
+      CREATE POLICY events_own_rows ON "${ctx.schema}"."events"
+        FOR ALL
+        USING (user_id::text = nullif(current_setting('request.jwt.claims', true), '')::json ->> 'sub')
+    `)
+  },
+
+  async inject(ctx) {
+    await ctx.sql(`
+      ALTER TABLE "${ctx.schema}"."events"
+        ALTER COLUMN occurred_at TYPE bigint
+        USING (extract(epoch FROM occurred_at)::bigint)
+    `)
+  },
+
+  async observe(ctx) {
+    // Graded on a WRITE, because this fault is invisible to every read.
+    const insert = await writeAs(
+      { role: 'authenticated', sub: TENANT_A },
+      `INSERT INTO "${ctx.schema}"."events" (user_id, occurred_at)
+       VALUES ($1, '2026-08-01T00:00:00Z'::timestamptz)`,
+      [TENANT_A],
+    )
+    const read = await readAs(
+      { role: 'authenticated', sub: TENANT_A },
+      `SELECT id FROM "${ctx.schema}"."events"`,
+    )
+    return {
+      // "Vulnerable" here means the defect is reproducible, not that data leaks.
+      vulnerable: !insert.ok,
+      functional: insert.ok && read.rows.length > 0,
+      evidence: insert.ok
+        ? `timestamp insert accepted; ${read.rows.length} row(s) readable by owner`
+        : `timestamp insert REJECTED by the column type: ${insert.error}`,
+    }
+  },
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 7. A policy that exists, passes review, and filters nothing
+// ─────────────────────────────────────────────────────────────────────────────
+
+const rlsWideOpenPolicy: FaultCase = {
+  id: 'rls-wide-open-policy',
+  title: 'Row-level security is enabled with a USING (true) policy, and anon can read',
+  task: 'detection',
+  scope: 'in_catalogue',
+  severity: 'critical',
+  crossPlatform: true,
+  impact:
+    'Worse than having no RLS, because every audit reports the table as protected. ' +
+    'RLS is on, a policy exists, and it matches every row for every caller — including ' +
+    'unauthenticated ones. This is the shape of the PostgREST cutover bug, where a blanket ' +
+    'GRANT handed `anon` SELECT on tables holding password hashes.',
+
+  async setup(ctx) {
+    await ctx.createTable(
+      'profiles',
+      `id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+       user_id uuid NOT NULL,
+       display_name text NOT NULL,
+       phone text NOT NULL`,
+    )
+    await ctx.sql(`
+      INSERT INTO "${ctx.schema}"."profiles" (user_id, display_name, phone) VALUES
+        ('${TENANT_A}', 'Tenant A', '+100000001'),
+        ('${TENANT_B}', 'Tenant B', '+100000002')
+    `)
+    await ctx.sql(`ALTER TABLE "${ctx.schema}"."profiles" ENABLE ROW LEVEL SECURITY`)
+    await ctx.sql(`
+      CREATE POLICY profiles_own_rows ON "${ctx.schema}"."profiles"
+        FOR ALL
+        USING (user_id::text = nullif(current_setting('request.jwt.claims', true), '')::json ->> 'sub')
+    `)
+  },
+
+  async inject(ctx) {
+    await ctx.sql(`DROP POLICY profiles_own_rows ON "${ctx.schema}"."profiles"`)
+    await ctx.sql(`
+      CREATE POLICY profiles_all_access ON "${ctx.schema}"."profiles"
+        FOR ALL USING (true)
+    `)
+    await ctx.sql(`GRANT SELECT ON "${ctx.schema}"."profiles" TO anon`)
+  },
+
+  async observe(ctx) {
+    // Graded from the unauthenticated seat. A signed-out request reaching real
+    // rows is the whole failure, and no authenticated read would reveal it.
+    const asAnon = await readAs({ role: 'anon' }, `SELECT phone FROM "${ctx.schema}"."profiles"`)
+    const asA = await readAs<{ user_id: string }>(
+      { role: 'authenticated', sub: TENANT_A },
+      `SELECT user_id FROM "${ctx.schema}"."profiles"`,
+    )
+    const own = asA.rows.filter((r) => r.user_id === TENANT_A).length
+    const foreign = asA.rows.filter((r) => r.user_id !== TENANT_A).length
+
+    return {
+      vulnerable: asAnon.rows.length > 0 || foreign > 0,
+      functional: own > 0,
+      evidence:
+        `unauthenticated anon read ${asAnon.rows.length} phone number(s); ` +
+        `authenticated sub=${TENANT_A.slice(0, 8)} saw ${own} own + ${foreign} foreign row(s)`,
+    }
+  },
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 8. Referential integrity removed
+// ─────────────────────────────────────────────────────────────────────────────
+
+const fkConstraintDropped: FaultCase = {
+  id: 'fk-constraint-dropped',
+  title: 'A foreign-key constraint was dropped, so orphan rows can be written',
+  task: 'mitigation',
+  scope: 'in_catalogue',
+  severity: 'warning',
+  crossPlatform: true,
+  impact:
+    'Child rows can be inserted pointing at parents that do not exist. Nothing fails at ' +
+    'write time; the corruption surfaces later as joins that silently drop rows, and by ' +
+    'then the bad data is spread through backups.',
+
+  async setup(ctx) {
+    await ctx.createTable(
+      'customers',
+      `id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+       user_id uuid NOT NULL`,
+    )
+    await ctx.createTable(
+      'subscriptions_t',
+      `id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+       customer_id uuid NOT NULL
+         CONSTRAINT subscriptions_customer_fk REFERENCES "${ctx.schema}"."customers"(id),
+       plan text NOT NULL`,
+    )
+    await ctx.sql(
+      `INSERT INTO "${ctx.schema}"."customers" (user_id) VALUES ('${TENANT_A}')`,
+    )
+  },
+
+  async inject(ctx) {
+    await ctx.sql(
+      `ALTER TABLE "${ctx.schema}"."subscriptions_t" DROP CONSTRAINT subscriptions_customer_fk`,
+    )
+  },
+
+  async observe(ctx) {
+    // Try to write a row whose parent does not exist. Rolled back either way.
+    const orphan = await writeAs(
+      { role: 'service_role' },
+      `INSERT INTO "${ctx.schema}"."subscriptions_t" (customer_id, plan)
+       VALUES ('99999999-9999-4999-8999-999999999999', 'pro')`,
+    )
+    const [parent] = await ctx.query<{ id: string }>(
+      `SELECT id FROM "${ctx.schema}"."customers" LIMIT 1`,
+    )
+    const valid = await writeAs(
+      { role: 'service_role' },
+      `INSERT INTO "${ctx.schema}"."subscriptions_t" (customer_id, plan) VALUES ($1, 'pro')`,
+      [parent?.id],
+    )
+
+    return {
+      vulnerable: orphan.ok,
+      functional: valid.ok,
+      evidence: orphan.ok
+        ? `orphan insert ACCEPTED (no FK constraint); legitimate insert ${valid.ok ? 'ok' : 'FAILED'}`
+        : `orphan insert correctly rejected; legitimate insert ${valid.ok ? 'ok' : 'FAILED'}`,
+    }
+  },
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 9. Reads isolated, writes wide open
+// ─────────────────────────────────────────────────────────────────────────────
+
+const rlsWritePathOpen: FaultCase = {
+  id: 'rls-write-path-over-permissive',
+  title: 'RLS filters reads correctly but permits writes to any row',
+  task: 'localization',
+  scope: 'in_catalogue',
+  severity: 'critical',
+  crossPlatform: true,
+  impact:
+    'Every read-based test passes and every screenshot looks correct — tenants genuinely ' +
+    'cannot SEE each other. They can still overwrite each other. A read-only audit of this ' +
+    'table reports it healthy, which is what makes it dangerous.',
+
+  async setup(ctx) {
+    await ctx.createTable(
+      'posts',
+      `id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+       user_id uuid NOT NULL,
+       body text NOT NULL`,
+    )
+    await ctx.sql(`
+      INSERT INTO "${ctx.schema}"."posts" (user_id, body) VALUES
+        ('${TENANT_A}', 'A post'), ('${TENANT_B}', 'B post')
+    `)
+    await ctx.sql(`ALTER TABLE "${ctx.schema}"."posts" ENABLE ROW LEVEL SECURITY`)
+    await ctx.sql(`
+      CREATE POLICY posts_own_rows ON "${ctx.schema}"."posts"
+        FOR ALL
+        USING (user_id::text = nullif(current_setting('request.jwt.claims', true), '')::json ->> 'sub')
+    `)
+  },
+
+  async inject(ctx) {
+    await ctx.sql(`DROP POLICY posts_own_rows ON "${ctx.schema}"."posts"`)
+    // Reads stay correctly scoped…
+    await ctx.sql(`
+      CREATE POLICY posts_read_own ON "${ctx.schema}"."posts"
+        FOR SELECT
+        USING (user_id::text = nullif(current_setting('request.jwt.claims', true), '')::json ->> 'sub')
+    `)
+    // …writes do not.
+    await ctx.sql(`
+      CREATE POLICY posts_write_any ON "${ctx.schema}"."posts"
+        FOR UPDATE USING (true) WITH CHECK (true)
+    `)
+  },
+
+  async observe(ctx) {
+    // The attack is an UNQUALIFIED update, and that detail is the case.
+    //
+    // A `WHERE id = <victim>` update cannot exploit this hole: PostgreSQL applies
+    // SELECT policies when locating rows for a qualified UPDATE, so the read
+    // policy hides the victim row and the attack touches nothing. The first
+    // version of this fixture did exactly that, and the harness correctly voided
+    // the case — the injection had not produced an exploitable fault.
+    //
+    // Without a WHERE clause there is no row to locate, so only the UPDATE
+    // policy's USING applies — and it says `true`. Tenant A rewrites every row
+    // in the table without ever being able to read one of them.
+    const attack = await writeAs(
+      { role: 'authenticated', sub: TENANT_A },
+      `UPDATE "${ctx.schema}"."posts" SET body = 'overwritten by A'`,
+    )
+    const ownRead = await readAs(
+      { role: 'authenticated', sub: TENANT_A },
+      `SELECT id FROM "${ctx.schema}"."posts"`,
+    )
+
+    // Tenant A legitimately owns exactly one row. Touching more than that means
+    // the write reached another tenant's data.
+    return {
+      vulnerable: attack.rowCount > 1,
+      functional: ownRead.rows.length > 0,
+      evidence:
+        `tenant A's unqualified UPDATE touched ${attack.rowCount} row(s) (owns 1); ` +
+        `tenant A can read ${ownRead.rows.length} of their own row(s)`,
+    }
+  },
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 10. OUT OF CATALOGUE — the identity sequence fell behind the data
+// ─────────────────────────────────────────────────────────────────────────────
+
+const sequenceDesync: FaultCase = {
+  id: 'sequence-desync',
+  title: 'The identity sequence is behind the table, so every insert collides',
+  task: 'rca',
+  scope: 'out_of_catalogue',
+  severity: 'critical',
+  crossPlatform: true,
+  impact:
+    'The classic aftermath of a restore or a bulk import: rows were written with explicit ' +
+    'ids and the sequence was never advanced. Reads are perfect, the schema is valid, and ' +
+    'every new insert fails on a duplicate primary key. No schema-shaped probe can see it, ' +
+    'because nothing about the schema is wrong.',
+
+  async setup(ctx) {
+    await ctx.createTable(
+      'tickets',
+      `id integer GENERATED BY DEFAULT AS IDENTITY PRIMARY KEY,
+       user_id uuid NOT NULL,
+       subject text NOT NULL`,
+    )
+    await ctx.sql(`
+      INSERT INTO "${ctx.schema}"."tickets" (user_id, subject) VALUES
+        ('${TENANT_A}', 'first'), ('${TENANT_A}', 'second')
+    `)
+  },
+
+  async inject(ctx) {
+    // Rewind the sequence beneath the existing rows.
+    await ctx.sql(`
+      SELECT setval(pg_get_serial_sequence('"${ctx.schema}"."tickets"', 'id'), 1, false)
+    `)
+  },
+
+  async observe(ctx) {
+    const insert = await writeAs(
+      { role: 'service_role' },
+      `INSERT INTO "${ctx.schema}"."tickets" (user_id, subject) VALUES ($1, 'new ticket')`,
+      [TENANT_A],
+    )
+    const read = await readAs(
+      { role: 'service_role' },
+      `SELECT id FROM "${ctx.schema}"."tickets"`,
+    )
+    return {
+      vulnerable: !insert.ok,
+      functional: insert.ok && read.rows.length > 0,
+      evidence: insert.ok
+        ? `insert accepted; ${read.rows.length} ticket(s) readable`
+        : `insert REJECTED: ${insert.error}`,
+    }
+  },
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 11. OUT OF CATALOGUE — the table became unreachable
+// ─────────────────────────────────────────────────────────────────────────────
+
+const grantRevoked: FaultCase = {
+  id: 'grant-revoked-unreachable',
+  title: 'SELECT was revoked from the end-user role, so the API 403s for everyone',
+  task: 'detection',
+  scope: 'out_of_catalogue',
+  severity: 'critical',
+  crossPlatform: true,
+  impact:
+    'A total outage for one table with no data loss and no schema change. RLS is correct, ' +
+    'the rows are intact, and every signed-in user gets permission denied. Exactly what a ' +
+    'careless REVOKE or a partial migration leaves behind.',
+
+  async setup(ctx) {
+    await ctx.createTable(
+      'messages',
+      `id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+       user_id uuid NOT NULL,
+       body text NOT NULL`,
+    )
+    await ctx.sql(`
+      INSERT INTO "${ctx.schema}"."messages" (user_id, body) VALUES
+        ('${TENANT_A}', 'hello'), ('${TENANT_B}', 'hi')
+    `)
+    await ctx.sql(`ALTER TABLE "${ctx.schema}"."messages" ENABLE ROW LEVEL SECURITY`)
+    await ctx.sql(`
+      CREATE POLICY messages_own_rows ON "${ctx.schema}"."messages"
+        FOR ALL
+        USING (user_id::text = nullif(current_setting('request.jwt.claims', true), '')::json ->> 'sub')
+    `)
+  },
+
+  async inject(ctx) {
+    await ctx.sql(
+      `REVOKE SELECT, INSERT, UPDATE, DELETE ON "${ctx.schema}"."messages" FROM authenticated`,
+    )
+  },
+
+  async observe(ctx) {
+    const asA = await readAs(
+      { role: 'authenticated', sub: TENANT_A },
+      `SELECT id FROM "${ctx.schema}"."messages"`,
+    )
+    return {
+      // The defect that reproduces here is an outage, not a leak. `vulnerable`
+      // means "the defect is observable", which a hard denial certainly is.
+      vulnerable: asA.denied,
+      functional: !asA.denied && asA.rows.length > 0,
+      evidence: asA.denied
+        ? `end-user role cannot reach messages at all: ${asA.error}`
+        : `end user reads ${asA.rows.length} of their own message(s)`,
+    }
+  },
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 12. OUT OF CATALOGUE — a validation rule quietly removed
+// ─────────────────────────────────────────────────────────────────────────────
+
+const checkConstraintDropped: FaultCase = {
+  id: 'check-constraint-dropped',
+  title: 'A CHECK constraint was dropped, so invalid data is now accepted',
+  task: 'mitigation',
+  scope: 'out_of_catalogue',
+  severity: 'warning',
+  crossPlatform: true,
+  impact:
+    'Negative amounts, empty required strings, out-of-range statuses — whatever the rule ' +
+    'protected is now writable. Nothing errors. The damage is discovered in reporting, ' +
+    'weeks later, mixed into real data.',
+
+  async setup(ctx) {
+    await ctx.createTable(
+      'payments',
+      `id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+       user_id uuid NOT NULL,
+       amount_cents integer NOT NULL
+         CONSTRAINT payments_amount_positive CHECK (amount_cents > 0)`,
+    )
+    await ctx.sql(
+      `INSERT INTO "${ctx.schema}"."payments" (user_id, amount_cents) VALUES ('${TENANT_A}', 500)`,
+    )
+  },
+
+  async inject(ctx) {
+    await ctx.sql(
+      `ALTER TABLE "${ctx.schema}"."payments" DROP CONSTRAINT payments_amount_positive`,
+    )
+  },
+
+  async observe(ctx) {
+    const bad = await writeAs(
+      { role: 'service_role' },
+      `INSERT INTO "${ctx.schema}"."payments" (user_id, amount_cents) VALUES ($1, -9999)`,
+      [TENANT_A],
+    )
+    const good = await writeAs(
+      { role: 'service_role' },
+      `INSERT INTO "${ctx.schema}"."payments" (user_id, amount_cents) VALUES ($1, 750)`,
+      [TENANT_A],
+    )
+    return {
+      vulnerable: bad.ok,
+      functional: good.ok,
+      evidence: bad.ok
+        ? `a -9999 cent payment was ACCEPTED; valid payment ${good.ok ? 'ok' : 'FAILED'}`
+        : `negative payment correctly rejected; valid payment ${good.ok ? 'ok' : 'FAILED'}`,
+    }
+  },
+}
+
+/**
+ * Corpus v1 — 12 cases: 7 in-catalogue, 1 control, 4 out-of-catalogue.
+ *
+ * The out-of-catalogue share is deliberately large and deliberately hard. After
+ * the advisory-lock fix the in-catalogue set scored 100%, and a clean sweep is
+ * the easiest possible thing to dismiss: "your corpus is too easy" is
+ * unanswerable unless the corpus visibly contains faults you do not handle.
+ * These four are real production failures — a rewound identity sequence, a
+ * revoked grant, a dropped CHECK, a narrowed column — chosen because no
+ * invariant in lib/autonomy/desired-state.ts claims them.
+ *
+ * They are expected to fail. Publish them failing.
+ */
+export const CORPUS_V1: FaultCase[] = [
+  rlsMissing,
+  rlsDenyAll,
+  engineDialectMismatch,
+  missingFkIndex,
+  rlsWideOpenPolicy,
+  fkConstraintDropped,
+  rlsWritePathOpen,
+  healthyControl,
+  columnTypeNarrowed,
+  sequenceDesync,
+  grantRevoked,
+  checkConstraintDropped,
+]

--- a/bench/selfops/env.ts
+++ b/bench/selfops/env.ts
@@ -1,0 +1,76 @@
+/**
+ * SELFOPS-BENCH — environment pinning
+ * ===================================
+ *
+ * MUST be the first import in any bench entry point. In ESM, imports execute in
+ * source order, so importing this module first is what guarantees the rewrite
+ * below happens before Prisma or any `pg` Pool reads its connection string.
+ *
+ * ── The bug this exists to prevent ──────────────────────────────────────────
+ *
+ * The benchmark reads through its own pool (`BENCH_DATABASE_URL`) but drives the
+ * real loop, and the loop's dependencies each open their own connection from
+ * `DATABASE_URL`: the Prisma singleton in lib/db/postgres, the pool in
+ * lib/autonomy/invariant-probes.ts, and every detector under lib/services.
+ *
+ * If those two variables disagree, the suite injects faults into one database
+ * and lets an autonomous repair loop mutate another. With a normal `.env`
+ * loaded, the second one is production. The failure is silent — the oracle
+ * would simply report that nothing ever got fixed, while the loop applied real
+ * schema changes to real customers.
+ *
+ * So there is exactly one connection string for a bench run, and everything is
+ * pinned to it.
+ */
+
+import * as dotenv from 'dotenv'
+
+dotenv.config()
+
+/**
+ * The single database a bench run may touch. `BENCH_DATABASE_URL` wins so a
+ * developer with a production `.env` on their machine gets the throwaway
+ * database, not the other way round.
+ */
+export const BENCH_DATABASE_URL =
+  process.env.BENCH_DATABASE_URL || process.env.TEST_DATABASE_URL || process.env.DATABASE_URL || ''
+
+if (!BENCH_DATABASE_URL) {
+  throw new Error(
+    'selfops-bench needs a database. Set BENCH_DATABASE_URL to a throwaway Postgres ' +
+    '(a CI service container or a local instance).',
+  )
+}
+
+// Pin every downstream consumer — Prisma, the probe pools, the detectors — to
+// the same instance the oracle grades. Without this the loop and the oracle can
+// silently address different databases.
+process.env.DATABASE_URL = BENCH_DATABASE_URL
+process.env.BENCH_DATABASE_URL = BENCH_DATABASE_URL
+// Prisma reads DIRECT_URL for non-pooled work; a stale value here would point
+// migrations and long queries back at whatever the ambient .env had.
+process.env.DIRECT_URL = BENCH_DATABASE_URL
+
+/**
+ * Refuse to benchmark production.
+ *
+ * The suite injects faults, lets an autonomous loop mutate schemas, and drops
+ * schemas on teardown. A string check is not real protection, but it catches
+ * the realistic accident: running with the ambient .env loaded on a laptop that
+ * also deploys.
+ */
+export function assertNotProduction(): void {
+  if (process.argv.includes('--i-know-this-is-not-production')) return
+  if (/prod|hetzner|amazonaws|neon\.tech|supabase\.co/i.test(BENCH_DATABASE_URL)) {
+    throw new Error(
+      `Refusing to run against what looks like a production database ` +
+      `(${BENCH_DATABASE_URL.replace(/\/\/[^@]+@/, '//***@')}). This suite injects faults and ` +
+      `lets an autonomous loop mutate schemas. Point BENCH_DATABASE_URL at a throwaway instance.`,
+    )
+  }
+}
+
+/** Connection string with credentials stripped, safe to print or publish. */
+export function redactedUrl(): string {
+  return BENCH_DATABASE_URL.replace(/\/\/[^@]+@/, '//***@')
+}

--- a/bench/selfops/harness.ts
+++ b/bench/selfops/harness.ts
@@ -153,11 +153,25 @@ export async function runCase(
       escalations += tick.escalated
       tokensSpent += tick.tokensSpent
 
-      // Detection is "the platform is holding an open finding for this project",
-      // which is the same thing the customer would see in the dashboard. It is
-      // recorded independently of repair so a platform that reliably sees the
-      // problem and cannot fix it scores honestly on detection.
-      if (ticksToDetect === null && tick.openFindings > 0) ticksToDetect = cycle
+      // Detection = the platform demonstrably located the fault this cycle.
+      //
+      // This was originally `openFindings > 0` alone, and that was a measurement
+      // bug, caught only by running on a second architecture. `openFindings` is
+      // sampled AFTER the cycle returns, so when the loop raises a finding,
+      // repairs it, and reaps it all within one cycle, the count reads zero and
+      // detection is never recorded — for a fault that was visibly repaired.
+      //
+      // It produced an impossible row: `rls-engine-dialect-mismatch` reported
+      // `detect=- repair=2` on Linux while reporting `detect=1` on Windows, from
+      // the same code against the same corpus. Nothing can be repaired without
+      // first being found, so a metric that says otherwise is measuring its own
+      // sampling window.
+      //
+      // An attempted repair is proof of detection, so it counts. This makes the
+      // detection number timing-independent rather than a race against the
+      // finding reaper.
+      const located = tick.openFindings > 0 || tick.attempted > 0 || tick.applied > 0
+      if (ticksToDetect === null && located) ticksToDetect = cycle
 
       after = await fault.observe(ctx)
       if (healthy(after)) {

--- a/bench/selfops/harness.ts
+++ b/bench/selfops/harness.ts
@@ -1,0 +1,209 @@
+/**
+ * SELFOPS-BENCH — the runner
+ * ==========================
+ *
+ * One case is one experiment, and the experiment is only valid if each step is
+ * proven rather than assumed:
+ *
+ *   1. BUILD a correct backend, then observe it. If the oracle does not read
+ *      clean here, the fixture is wrong and the case is void — not a pass.
+ *      Skipping this check is how a suite ends up "healing" backends that were
+ *      never broken.
+ *
+ *   2. INJECT the fault, then observe again. If the backend still reads clean,
+ *      the injection did not take. That is `never_faulted`, and it is scored as
+ *      a void case, never as a success. A benchmark that counts failed
+ *      injections as passes is a benchmark that improves when it breaks.
+ *
+ *   3. CYCLE the platform's loop, observing between every cycle, until the
+ *      oracle reads healthy or the budget runs out.
+ *
+ *   4. GRADE from the final observation only. The platform's own opinion of
+ *      what it repaired is recorded in the trace for the reader, and is not an
+ *      input to the verdict.
+ *
+ * ── Stall detection ─────────────────────────────────────────────────────────
+ *
+ * A loop that has stopped acting will not start again on cycle 40 if it did
+ * nothing on cycles 5 through 12. Running the full budget anyway would multiply
+ * suite runtime for no information, so a case ends early once the loop has been
+ * idle — no repairs, no new findings — for `STALL_CYCLES` consecutive cycles.
+ * The result records that it ended on a stall rather than on the budget, since
+ * "gave up after 3 idle cycles" and "still trying at cycle 40" are different
+ * claims about a platform.
+ */
+
+import type {
+  CaseResult,
+  FaultCase,
+  LaneAdapter,
+  Observation,
+  TickResult,
+} from './types'
+import { verdictFor } from './types'
+
+/** Cycles a case gets before it is declared unhealed. */
+export const DEFAULT_MAX_CYCLES = 12
+
+/** Consecutive idle cycles after which the loop is considered to have stopped. */
+export const STALL_CYCLES = 4
+
+export interface RunOptions {
+  maxCycles?: number
+  /** Called after every cycle so a long run is not silent. */
+  onProgress?: (caseId: string, cycle: number, tick: TickResult) => void
+}
+
+const healthy = (o: Observation): boolean => !o.vulnerable && o.functional
+
+/** Flatten any thrown value into something a reader of the receipt can act on. */
+function describeError(err: any): string {
+  if (!err) return 'unknown error (nothing was thrown)'
+  const parts = [
+    err.name && err.name !== 'Error' ? err.name : null,
+    err.code ? `[${err.code}]` : null,
+    err.message || null,
+    // Prisma surfaces the useful detail here when `message` is empty.
+    err.meta ? `meta=${JSON.stringify(err.meta)}` : null,
+    err.detail || null,
+  ].filter(Boolean)
+  const head = parts.length ? parts.join(' ') : String(err)
+  const frame = typeof err.stack === 'string'
+    ? err.stack.split('\n').slice(1, 3).map((s: string) => s.trim()).join(' <- ')
+    : ''
+  return frame ? `${head} (${frame})` : head
+}
+
+export async function runCase(
+  fault: FaultCase,
+  lane: LaneAdapter,
+  options: RunOptions = {},
+): Promise<CaseResult> {
+  const maxCycles = options.maxCycles ?? DEFAULT_MAX_CYCLES
+
+  const base: CaseResult = {
+    caseId: fault.id,
+    lane: lane.name,
+    task: fault.task,
+    scope: fault.scope,
+    severity: fault.severity,
+    crossPlatform: fault.crossPlatform,
+    verdict: 'harness_error',
+    before: null,
+    after: null,
+    ticksToDetect: null,
+    ticksToRepair: null,
+    ticksRun: 0,
+    fixesApplied: 0,
+    escalations: 0,
+    tokensSpent: 0,
+    trace: [],
+  }
+
+  let ctx: Awaited<ReturnType<LaneAdapter['provision']>> | null = null
+
+  try {
+    ctx = await lane.provision()
+
+    // ── 1. The fixture must start clean ──────────────────────────────────────
+    await fault.setup(ctx)
+    const baseline = await fault.observe(ctx)
+    if (!healthy(baseline)) {
+      return {
+        ...base,
+        before: baseline,
+        error:
+          `Fixture did not start healthy (vulnerable=${baseline.vulnerable} ` +
+          `functional=${baseline.functional}): ${baseline.evidence}. The case cannot ` +
+          `attribute anything to the injection, so it is void rather than failed.`,
+      }
+    }
+
+    // ── 2. The injection must actually break something ───────────────────────
+    await fault.inject(ctx)
+    const before = await fault.observe(ctx)
+    if (healthy(before)) {
+      return {
+        ...base,
+        before,
+        verdict: 'never_faulted',
+        error:
+          `Injection left the backend healthy: ${before.evidence}. Scored as void — ` +
+          `a case whose fault never existed must never count as a repair.`,
+      }
+    }
+
+    // ── 3. Cycle the loop ────────────────────────────────────────────────────
+    const trace: TickResult[] = []
+    let ticksToDetect: number | null = null
+    let ticksToRepair: number | null = null
+    let fixesApplied = 0
+    let escalations = 0
+    let tokensSpent = 0
+    let idleCycles = 0
+    let lastFindings = -1
+    let after: Observation = before
+
+    for (let cycle = 1; cycle <= maxCycles; cycle++) {
+      const tick = await lane.tick(ctx)
+      trace.push(tick)
+      options.onProgress?.(fault.id, cycle, tick)
+
+      fixesApplied += tick.applied
+      escalations += tick.escalated
+      tokensSpent += tick.tokensSpent
+
+      // Detection is "the platform is holding an open finding for this project",
+      // which is the same thing the customer would see in the dashboard. It is
+      // recorded independently of repair so a platform that reliably sees the
+      // problem and cannot fix it scores honestly on detection.
+      if (ticksToDetect === null && tick.openFindings > 0) ticksToDetect = cycle
+
+      after = await fault.observe(ctx)
+      if (healthy(after)) {
+        ticksToRepair = cycle
+        break
+      }
+
+      const idle =
+        tick.applied === 0 && tick.attempted === 0 && tick.openFindings === lastFindings
+      idleCycles = idle ? idleCycles + 1 : 0
+      lastFindings = tick.openFindings
+      if (idleCycles >= STALL_CYCLES) break
+    }
+
+    return {
+      ...base,
+      verdict: verdictFor(after),
+      before,
+      after,
+      ticksToDetect,
+      ticksToRepair,
+      ticksRun: trace.length,
+      fixesApplied,
+      escalations,
+      tokensSpent,
+      trace,
+    }
+  } catch (err: any) {
+    // Capture enough to diagnose from the receipt alone. Prisma and pg both
+    // throw errors whose `message` can be empty while `code` and the stack
+    // carry the whole story, and a published result file that says only
+    // `"error": ""` is worse than no result file.
+    return { ...base, error: describeError(err) }
+  } finally {
+    if (ctx) await lane.teardown(ctx).catch(() => {})
+  }
+}
+
+export async function runSuite(
+  cases: FaultCase[],
+  lane: LaneAdapter,
+  options: RunOptions = {},
+): Promise<CaseResult[]> {
+  const results: CaseResult[] = []
+  for (const fault of cases) {
+    results.push(await runCase(fault, lane, options))
+  }
+  return results
+}

--- a/bench/selfops/oracle.ts
+++ b/bench/selfops/oracle.ts
@@ -1,0 +1,281 @@
+/**
+ * SELFOPS-BENCH — the oracle
+ * ==========================
+ *
+ * How a case is graded. Never by asking a probe.
+ *
+ * Every reading here is taken over a Postgres connection configured exactly the
+ * way PostgREST configures one when it serves an end-user request:
+ *
+ *   SET LOCAL ROLE authenticated;
+ *   SELECT set_config('request.jwt.claims', '{"sub":"…","role":"authenticated"}', true);
+ *
+ * That is not an approximation of the data plane — it IS the data plane's
+ * security context. `lib/postgrest/rls-translation.ts` compiles every policy
+ * against `request.jwt.claims`, so a policy that passes here passes in
+ * production and a policy that leaks here leaks in production.
+ *
+ * Two things this deliberately does NOT do:
+ *
+ *   • It does not connect as the owner. Table owners bypass row-level security
+ *     unless FORCE ROW LEVEL SECURITY is set, so an owner connection reports a
+ *     wide-open table and a locked table identically. Reading as the owner is
+ *     the single easiest way to write a security benchmark that always passes.
+ *
+ *   • It does not treat `permission denied` as "no rows". A missing GRANT and a
+ *     working RLS policy both yield zero rows to a careless caller, and they
+ *     mean completely different things — one is a broken deployment, the other
+ *     is the feature working. They are separate outcomes below.
+ *
+ * Every read runs inside a transaction that is always rolled back, so grading a
+ * backend can never mutate it.
+ */
+
+import { Pool, type PoolClient } from 'pg'
+
+/** Roles PostgREST serves requests under. Mirrors scripts/setup-postgrest-roles.ts. */
+export type DataPlaneRole = 'anon' | 'authenticated' | 'service_role'
+
+export interface ReadOutcome<T = Record<string, unknown>> {
+  /** Rows visible to this identity. Empty when RLS filtered everything out. */
+  rows: T[]
+  /**
+   * True when Postgres refused the statement outright (missing GRANT, missing
+   * relation). Distinct from an empty result, which is RLS doing its job.
+   */
+  denied: boolean
+  /** The raw error, when the statement did not run at all. */
+  error?: string
+}
+
+let pool: Pool | null = null
+
+function getPool(): Pool {
+  if (!pool) {
+    const connectionString = process.env.BENCH_DATABASE_URL || process.env.DATABASE_URL
+    if (!connectionString) {
+      throw new Error(
+        'selfops-bench needs a database. Set BENCH_DATABASE_URL (preferred — it keeps the ' +
+        'benchmark off any database you care about) or DATABASE_URL.',
+      )
+    }
+    pool = new Pool({ connectionString, max: 8 })
+  }
+  return pool
+}
+
+export async function closeOracle(): Promise<void> {
+  if (pool) {
+    await pool.end().catch(() => {})
+    pool = null
+  }
+}
+
+/** Run a statement as the schema owner. Fixture construction only — never grading. */
+export async function ownerExec(statement: string, params: unknown[] = []): Promise<void> {
+  const client = await getPool().connect()
+  try {
+    await client.query(statement, params)
+  } finally {
+    client.release()
+  }
+}
+
+/** Query as the schema owner. Fixture construction only — never grading. */
+export async function ownerQuery<T = Record<string, unknown>>(
+  statement: string,
+  params: unknown[] = [],
+): Promise<T[]> {
+  const client = await getPool().connect()
+  try {
+    const res = await client.query(statement, params)
+    return res.rows as T[]
+  } finally {
+    client.release()
+  }
+}
+
+/**
+ * Make sure the three PostgREST roles exist and that the benchmark's connection
+ * may assume them.
+ *
+ * The bench must be able to run against a bare Postgres (a CI service
+ * container) as well as against a full platform database where
+ * scripts/setup-postgrest-roles.ts has already run. Both are idempotent here.
+ *
+ * The GRANT to CURRENT_USER is what lets `SET LOCAL ROLE` work when the bench
+ * connects as a non-superuser. Without it the oracle would fail closed on every
+ * case and the suite would report a platform-wide outage that is really a
+ * harness misconfiguration — so this is loud when it cannot be satisfied.
+ */
+export async function ensureDataPlaneRoles(): Promise<void> {
+  // The application role. Production runs as `backenly_user`, and the PostgREST
+  // helper SQL hardcodes it: `backenly_pgrst_prepare_schema` (installed as a
+  // CREATE SCHEMA event trigger) executes
+  // `ALTER DEFAULT PRIVILEGES FOR ROLE backenly_user`, so on a database where
+  // the role is absent, *creating a workspace schema fails outright* and every
+  // case dies in provisioning. Creating it here keeps the bench runnable on a
+  // bare Postgres while matching the production role graph.
+  await ownerExec(`
+    DO $$
+    BEGIN
+      IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'backenly_user') THEN
+        CREATE ROLE backenly_user NOLOGIN;
+      END IF;
+      -- The PostgREST connection role. NOINHERIT is what keeps it powerless: it
+      -- may only ACT as anon/authenticated/service_role by switching to them,
+      -- never by holding their privileges directly. Re-asserted rather than set
+      -- once, exactly as scripts/setup-postgrest-roles.ts does, so a bench
+      -- database cannot drift into a weaker posture than production.
+      IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'backenly_authenticator') THEN
+        CREATE ROLE backenly_authenticator LOGIN NOINHERIT;
+      END IF;
+    END
+    $$;
+  `)
+  await ownerExec(`ALTER ROLE backenly_authenticator NOINHERIT`)
+
+  const roles: DataPlaneRole[] = ['anon', 'authenticated', 'service_role']
+  for (const role of roles) {
+    await ownerExec(`
+      DO $$
+      BEGIN
+        IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = '${role}') THEN
+          CREATE ROLE ${role} NOLOGIN;
+        END IF;
+      END
+      $$;
+    `)
+    // Superusers can SET ROLE unconditionally; everyone else needs membership.
+    await ownerExec(`
+      DO $$
+      BEGIN
+        IF NOT (SELECT rolsuper FROM pg_roles WHERE rolname = CURRENT_USER) THEN
+          EXECUTE format('GRANT ${role} TO %I', CURRENT_USER);
+        END IF;
+      END
+      $$;
+    `)
+    await ownerExec(`GRANT ${role} TO backenly_authenticator`)
+  }
+}
+
+/**
+ * Apply the same grants the platform applies to a workspace schema.
+ *
+ * Deliberately mirrors setup-postgrest-roles.ts INCLUDING its narrowness: `anon`
+ * gets SELECT only, and this is applied per-table by the caller rather than as a
+ * blanket `ALL TABLES` grant. The blanket form is what handed `anon`
+ * unauthenticated SELECT on password hashes during the PostgREST cutover; the
+ * benchmark should not quietly reintroduce the exact grant that was the bug.
+ */
+export async function grantTableAccess(schema: string, table: string): Promise<void> {
+  await ownerExec(`GRANT USAGE ON SCHEMA "${schema}" TO anon, authenticated, service_role`)
+  await ownerExec(
+    `GRANT SELECT, INSERT, UPDATE, DELETE ON "${schema}"."${table}" TO authenticated, service_role`,
+  )
+}
+
+/**
+ * Read the backend as a specific end-user identity, exactly as PostgREST would.
+ *
+ * `sub` is the end-user id that lands in `request.jwt.claims->>'sub'`, which is
+ * what every translated own-rows policy compares against.
+ */
+export async function readAs<T = Record<string, unknown>>(
+  identity: { role: DataPlaneRole; sub?: string },
+  statement: string,
+  params: unknown[] = [],
+): Promise<ReadOutcome<T>> {
+  const client: PoolClient = await getPool().connect()
+  try {
+    await client.query('BEGIN')
+    // Claims first: SET ROLE drops the privilege needed to set a GUC on some
+    // configurations, and PostgREST itself sets claims before switching role.
+    const claims = JSON.stringify({
+      role: identity.role,
+      ...(identity.sub ? { sub: identity.sub } : {}),
+    })
+    await client.query(`SELECT set_config('request.jwt.claims', $1, true)`, [claims])
+    await client.query(`SET LOCAL ROLE ${identity.role}`)
+
+    const res = await client.query(statement, params)
+    return { rows: res.rows as T[], denied: false }
+  } catch (err: any) {
+    // 42501 insufficient_privilege · 42P01 undefined_table — the statement never
+    // ran, so this is emphatically not "zero rows".
+    const denied = err?.code === '42501' || err?.code === '42P01'
+    return { rows: [], denied, error: err?.message ?? String(err) }
+  } finally {
+    await client.query('ROLLBACK').catch(() => {})
+    client.release()
+  }
+}
+
+/**
+ * Attempt a write as an end-user identity. Always rolled back.
+ *
+ * Needed because read-only grading cannot see a whole class of real faults: a
+ * column narrowed to the wrong type, a NOT NULL added under live rows, a policy
+ * that permits SELECT but silently blocks INSERT. Those backends read perfectly
+ * and are still broken for the customer's app.
+ */
+export async function writeAs(
+  identity: { role: DataPlaneRole; sub?: string },
+  statement: string,
+  params: unknown[] = [],
+): Promise<{ ok: boolean; error?: string; denied: boolean; rowCount: number }> {
+  const client: PoolClient = await getPool().connect()
+  try {
+    await client.query('BEGIN')
+    const claims = JSON.stringify({
+      role: identity.role,
+      ...(identity.sub ? { sub: identity.sub } : {}),
+    })
+    await client.query(`SELECT set_config('request.jwt.claims', $1, true)`, [claims])
+    await client.query(`SET LOCAL ROLE ${identity.role}`)
+    const res = await client.query(statement, params)
+    // rowCount is load-bearing, not decoration. An UPDATE that RLS filters down
+    // to zero rows succeeds — same `ok: true`, same absence of error — as one
+    // that rewrote another tenant's data. Without the count, a write-path
+    // authorization hole and a correctly-enforced policy are indistinguishable,
+    // and the oracle would score the hole as safe.
+    return { ok: true, denied: false, rowCount: res.rowCount ?? 0 }
+  } catch (err: any) {
+    const denied = err?.code === '42501' || err?.code === '42P01'
+    return { ok: false, denied, error: err?.message ?? String(err), rowCount: 0 }
+  } finally {
+    await client.query('ROLLBACK').catch(() => {})
+    client.release()
+  }
+}
+
+/**
+ * Whether a query against `table` filtered by `column` uses an index.
+ *
+ * Graded from the planner rather than from pg_indexes, because the fault being
+ * measured is "this query got slow", not "a row is missing from a catalog
+ * table". An index that exists but that the planner will not use has not fixed
+ * anything, and only EXPLAIN can tell the difference.
+ *
+ * Rows are seeded past the point where a sequential scan is genuinely cheaper,
+ * so a Seq Scan here is a real planner preference and not small-table noise.
+ */
+export async function usesIndexScan(
+  schema: string,
+  table: string,
+  column: string,
+  value: unknown,
+): Promise<{ indexed: boolean; plan: string }> {
+  const rows = await ownerQuery<{ 'QUERY PLAN': any }>(
+    `EXPLAIN (FORMAT JSON) SELECT * FROM "${schema}"."${table}" WHERE "${column}" = $1`,
+    [value],
+  )
+  const plan = rows[0]?.['QUERY PLAN']
+  const text = JSON.stringify(plan ?? {})
+  const nodeType = plan?.[0]?.Plan?.['Node Type'] ?? 'unknown'
+  return {
+    indexed: /Index Scan|Index Only Scan|Bitmap Index Scan/.test(text),
+    plan: nodeType,
+  }
+}

--- a/bench/selfops/report.ts
+++ b/bench/selfops/report.ts
@@ -1,0 +1,272 @@
+/**
+ * SELFOPS-BENCH — scoring and report
+ * ==================================
+ *
+ * Scoring rules, stated once so they cannot drift between runs:
+ *
+ *   • The headline is REPAIR RATE over faults that were successfully injected.
+ *     `never_faulted` and `harness_error` cases are excluded from the
+ *     denominator AND printed anyway, so excluding them can never quietly
+ *     inflate a score.
+ *
+ *   • `over_corrected` counts as a FAILURE. A backend that no longer leaks
+ *     because nobody can read it has not been repaired.
+ *
+ *   • The control arm is scored inversely: every finding it raised and every
+ *     mutation it applied is a false positive. It is reported next to the
+ *     repair rate, not in a footnote, because a high repair rate paid for with
+ *     unrequested changes to healthy backends is not a good result.
+ *
+ *   • Out-of-catalogue cases are reported separately and are expected to fail.
+ *     They are not averaged into the headline — that would let the corpus be
+ *     padded with unfixable cases to make the in-catalogue number look modest,
+ *     or trimmed to make it look good. They are the honesty column.
+ */
+
+import type { CaseResult } from './types'
+
+export interface Scorecard {
+  lane: string
+  generatedAt: string
+  /** Cases where the injection took and the fault was in the catalogue. */
+  scored: number
+  healed: number
+  notRepaired: number
+  overCorrected: number
+  degraded: number
+  detected: number
+  void: number
+  errors: number
+  repairRate: number | null
+  detectionRate: number | null
+  /** Median cycles from injection to a verified-healthy oracle reading. */
+  medianCyclesToRepair: number | null
+  medianCyclesToDetect: number | null
+  totalTokens: number
+  control: {
+    ran: boolean
+    findingsRaised: number
+    mutationsApplied: number
+  }
+  outOfCatalogue: {
+    total: number
+    healed: number
+  }
+}
+
+const median = (xs: number[]): number | null => {
+  if (xs.length === 0) return null
+  const s = [...xs].sort((a, b) => a - b)
+  const mid = Math.floor(s.length / 2)
+  return s.length % 2 ? s[mid] : (s[mid - 1] + s[mid]) / 2
+}
+
+export function score(results: CaseResult[], lane: string): Scorecard {
+  const control = results.find((r) => r.caseId === 'control-healthy-backend')
+  const nonControl = results.filter((r) => r.caseId !== 'control-healthy-backend')
+
+  const outOfCat = nonControl.filter((r) => r.scope === 'out_of_catalogue')
+  const inCat = nonControl.filter((r) => r.scope === 'in_catalogue')
+
+  const scorable = inCat.filter(
+    (r) => r.verdict !== 'never_faulted' && r.verdict !== 'harness_error',
+  )
+
+  const healed = scorable.filter((r) => r.verdict === 'healed')
+  const repairCycles = healed
+    .map((r) => r.ticksToRepair)
+    .filter((n): n is number => n !== null)
+  const detectCycles = scorable
+    .map((r) => r.ticksToDetect)
+    .filter((n): n is number => n !== null)
+
+  return {
+    lane,
+    generatedAt: new Date().toISOString(),
+    scored: scorable.length,
+    healed: healed.length,
+    notRepaired: scorable.filter((r) => r.verdict === 'not_repaired').length,
+    overCorrected: scorable.filter((r) => r.verdict === 'over_corrected').length,
+    degraded: scorable.filter((r) => r.verdict === 'degraded').length,
+    detected: detectCycles.length,
+    void: nonControl.filter((r) => r.verdict === 'never_faulted').length,
+    errors: nonControl.filter((r) => r.verdict === 'harness_error').length,
+    repairRate: scorable.length ? healed.length / scorable.length : null,
+    detectionRate: scorable.length ? detectCycles.length / scorable.length : null,
+    medianCyclesToRepair: median(repairCycles),
+    medianCyclesToDetect: median(detectCycles),
+    totalTokens: results.reduce((n, r) => n + r.tokensSpent, 0),
+    control: {
+      ran: !!control && control.verdict !== 'harness_error',
+      findingsRaised: control ? Math.max(0, ...control.trace.map((t) => t.openFindings), 0) : 0,
+      mutationsApplied: control ? control.fixesApplied : 0,
+    },
+    outOfCatalogue: {
+      total: outOfCat.length,
+      healed: outOfCat.filter((r) => r.verdict === 'healed').length,
+    },
+  }
+}
+
+const pct = (n: number | null): string => (n === null ? 'n/a' : `${Math.round(n * 100)}%`)
+
+const VERDICT_MARK: Record<string, string> = {
+  healed: 'PASS',
+  not_repaired: 'FAIL',
+  over_corrected: 'FAIL (over-corrected)',
+  degraded: 'FAIL (degraded)',
+  never_faulted: 'VOID',
+  harness_error: 'ERROR',
+}
+
+export function toMarkdown(
+  results: CaseResult[],
+  card: Scorecard,
+  meta: { healer: string; autonomyLevel: string; plan: string; maxCycles: number },
+): string {
+  const lines: string[] = []
+
+  lines.push(`# selfops-bench v1 — ${card.lane}`)
+  lines.push('')
+  lines.push(`Generated ${card.generatedAt}`)
+  lines.push('')
+  lines.push(`- **Healer:** ${meta.healer}`)
+  lines.push(`- **Plan / dial:** ${meta.plan} / ${meta.autonomyLevel}`)
+  lines.push(`- **Cycle budget:** ${meta.maxCycles} per case`)
+  lines.push('')
+  lines.push('## Headline')
+  lines.push('')
+  lines.push('| Metric | Value |')
+  lines.push('| --- | --- |')
+  lines.push(`| Repair rate (in-catalogue, unattended) | **${pct(card.repairRate)}** (${card.healed}/${card.scored}) |`)
+  lines.push(`| Detection rate | ${pct(card.detectionRate)} (${card.detected}/${card.scored}) |`)
+  lines.push(`| Median cycles to detect | ${card.medianCyclesToDetect ?? 'never'} |`)
+  lines.push(`| Median cycles to repair | ${card.medianCyclesToRepair ?? 'never'} |`)
+  lines.push(`| Over-corrected (secured into uselessness) | ${card.overCorrected} |`)
+  lines.push(`| Degraded (made worse) | ${card.degraded} |`)
+  lines.push(`| **Control false positives** — findings raised on a healthy backend | **${card.control.findingsRaised}** |`)
+  lines.push(`| **Control unrequested mutations** | **${card.control.mutationsApplied}** |`)
+  lines.push(`| Out-of-catalogue faults repaired | ${card.outOfCatalogue.healed}/${card.outOfCatalogue.total} |`)
+  lines.push(`| Model tokens spent across the whole suite | ${card.totalTokens} |`)
+  lines.push('')
+  lines.push(
+    'Cycles, not seconds: one cycle is one full pass of the maintenance loop. Wall-clock ' +
+    'MTTR is `cycles x cadence`; this platform reconciles every minute on every plan, so ' +
+    'a 2-cycle repair is roughly a 2-minute repair in production.',
+  )
+  lines.push('')
+  lines.push('## Per case')
+  lines.push('')
+  lines.push('| Case | Task | Scope | Severity | Result | Detect | Repair | Evidence after |')
+  lines.push('| --- | --- | --- | --- | --- | --- | --- | --- |')
+  for (const r of results) {
+    lines.push(
+      `| \`${r.caseId}\` | ${r.task} | ${r.scope.replace('_', '-')} | ${r.severity} | ` +
+      `${VERDICT_MARK[r.verdict] ?? r.verdict} | ${r.ticksToDetect ?? '—'} | ` +
+      `${r.ticksToRepair ?? '—'} | ${r.after?.evidence ?? r.error ?? '—'} |`,
+    )
+  }
+  lines.push('')
+  lines.push('## What each verdict means')
+  lines.push('')
+  lines.push('- **PASS** — an oracle outside the control plane confirms the defect is gone *and* the legitimate path still works.')
+  lines.push('- **FAIL (over-corrected)** — the defect is gone because the feature is broken. Scored as a failure.')
+  lines.push('- **VOID** — the injection did not produce the fault, so nothing can be concluded. Never counted as a pass.');
+  lines.push('')
+
+  const failures = results.filter((r) => r.verdict !== 'healed' && r.caseId !== 'control-healthy-backend')
+  if (failures.length) {
+    lines.push('## Failures in full')
+    lines.push('')
+    for (const f of failures) {
+      lines.push(`### \`${f.caseId}\` — ${VERDICT_MARK[f.verdict] ?? f.verdict}`)
+      lines.push('')
+      if (f.before) lines.push(`- After injection: ${f.before.evidence}`)
+      if (f.after) lines.push(`- After ${f.ticksRun} cycle(s): ${f.after.evidence}`)
+      if (f.error) lines.push(`- Harness: ${f.error}`)
+      lines.push(`- Loop activity: ${f.fixesApplied} repair(s) applied, ${f.escalations} escalated`)
+      lines.push('')
+    }
+  }
+
+  return lines.join('\n')
+}
+
+/**
+ * Stability across repeated runs.
+ *
+ * A benchmark's whole value is reproducibility, and the two numbers most worth
+ * publishing here — zero control false positives, zero tokens — are exactly the
+ * kind that look great once and then move. This turns "it scored 100%" into
+ * "it scored 100% n times out of n", which is a different and much stronger
+ * sentence. Any case that is not unanimous is called out by name: a flaky case
+ * is either a flaky platform or a flaky fixture, and both need fixing before
+ * anyone quotes the median.
+ */
+export function stabilityReport(runs: CaseResult[][], caseIds: string[]): string {
+  const n = runs.length
+  const lines: string[] = ['', `stability across ${n} runs`, '']
+
+  let unstable = 0
+  for (const id of caseIds) {
+    const verdicts = runs.map((r) => r.find((x) => x.caseId === id)?.verdict ?? 'harness_error')
+    const passes = verdicts.filter((v) => v === 'healed').length
+    const voids = verdicts.filter((v) => v === 'never_faulted').length
+    const distinct = new Set(verdicts)
+    const stable = distinct.size === 1
+    if (!stable) unstable++
+
+    const cycles = runs
+      .map((r) => r.find((x) => x.caseId === id)?.ticksToRepair)
+      .filter((c): c is number => typeof c === 'number')
+    const cycleRange = cycles.length
+      ? cycles.every((c) => c === cycles[0])
+        ? ` repair=${cycles[0]}`
+        : ` repair=${Math.min(...cycles)}-${Math.max(...cycles)}`
+      : ''
+
+    lines.push(
+      `  ${stable ? ' ' : '!'} ${id.padEnd(30)} ` +
+      `${voids === n ? `void x${n}` : `${passes}/${n} healed`}${cycleRange}` +
+      (stable ? '' : `  UNSTABLE: ${[...distinct].join(', ')}`),
+    )
+  }
+
+  const fps = runs.map((r) => {
+    const c = r.find((x) => x.caseId === 'control-healthy-backend')
+    return c ? Math.max(0, ...c.trace.map((t) => t.openFindings), 0) + c.fixesApplied : 0
+  })
+  const tokens = runs.map((r) => r.reduce((s, x) => s + x.tokensSpent, 0))
+
+  lines.push('')
+  lines.push(`  control false positives per run : ${fps.join(', ')}`)
+  lines.push(`  tokens per run                  : ${tokens.join(', ')}`)
+  lines.push(
+    unstable === 0
+      ? `  every case gave the same verdict in all ${n} runs.`
+      : `  ${unstable} case(s) VARIED between runs — do not quote a median over these.`,
+  )
+  lines.push('')
+  return lines.join('\n')
+}
+
+export function toConsole(results: CaseResult[], card: Scorecard): string {
+  const rows = results.map((r) => {
+    const mark = r.verdict === 'healed' ? 'PASS' : r.verdict === 'never_faulted' ? 'VOID' : 'FAIL'
+    return `  ${mark.padEnd(5)} ${r.caseId.padEnd(30)} detect=${String(r.ticksToDetect ?? '-').padEnd(3)} repair=${String(r.ticksToRepair ?? '-').padEnd(3)} ${r.after?.evidence ?? r.error ?? ''}`
+  })
+  return [
+    '',
+    `selfops-bench v1 — ${card.lane}`,
+    '',
+    ...rows,
+    '',
+    `  repair rate     ${pct(card.repairRate)} (${card.healed}/${card.scored} in-catalogue)`,
+    `  detection rate  ${pct(card.detectionRate)}`,
+    `  over-corrected  ${card.overCorrected}`,
+    `  control FPs     ${card.control.findingsRaised} finding(s), ${card.control.mutationsApplied} mutation(s)`,
+    `  out-of-cat      ${card.outOfCatalogue.healed}/${card.outOfCatalogue.total} repaired`,
+    `  tokens          ${card.totalTokens}`,
+    '',
+  ].join('\n')
+}

--- a/bench/selfops/results/backenly-autopilot-2026-08-01T05-16-10-853Z.json
+++ b/bench/selfops/results/backenly-autopilot-2026-08-01T05-16-10-853Z.json
@@ -1,0 +1,72 @@
+{
+  "meta": {
+    "healer": "resident MAPE-K loop (lib/autonomy/reconciler.ts) — no agent, no session, no human",
+    "autonomyLevel": "AGGRESSIVE",
+    "plan": "SANDBOX",
+    "maxCycles": 3
+  },
+  "card": {
+    "lane": "backenly-autopilot",
+    "generatedAt": "2026-08-01T05:16:10.852Z",
+    "scored": 1,
+    "healed": 1,
+    "notRepaired": 0,
+    "overCorrected": 0,
+    "degraded": 0,
+    "detected": 1,
+    "void": 0,
+    "errors": 0,
+    "repairRate": 1,
+    "detectionRate": 1,
+    "medianCyclesToRepair": 1,
+    "medianCyclesToDetect": 1,
+    "totalTokens": 0,
+    "control": {
+      "ran": false,
+      "findingsRaised": 0,
+      "mutationsApplied": 0
+    },
+    "outOfCatalogue": {
+      "total": 0,
+      "healed": 0
+    }
+  },
+  "results": [
+    {
+      "caseId": "rls-cross-tenant-read",
+      "lane": "backenly-autopilot",
+      "task": "mitigation",
+      "scope": "in_catalogue",
+      "severity": "critical",
+      "crossPlatform": true,
+      "verdict": "healed",
+      "before": {
+        "vulnerable": true,
+        "functional": true,
+        "evidence": "role authenticated with sub=11111111 read 2 own row(s) and 1 row(s) belonging to another user"
+      },
+      "after": {
+        "vulnerable": false,
+        "functional": true,
+        "evidence": "role authenticated with sub=11111111 read 2 own row(s) and 0 row(s) belonging to another user"
+      },
+      "ticksToDetect": 1,
+      "ticksToRepair": 1,
+      "ticksRun": 1,
+      "fixesApplied": 1,
+      "escalations": 0,
+      "tokensSpent": 0,
+      "trace": [
+        {
+          "openFindings": 1,
+          "attempted": 2,
+          "applied": 1,
+          "escalated": 0,
+          "blocked": true,
+          "note": "1 repair(s) deferred by the mutation cooldown",
+          "tokensSpent": 0
+        }
+      ]
+    }
+  ]
+}

--- a/bench/selfops/results/backenly-autopilot-2026-08-01T05-16-10-853Z.md
+++ b/bench/selfops/results/backenly-autopilot-2026-08-01T05-16-10-853Z.md
@@ -1,0 +1,36 @@
+# selfops-bench v1 — backenly-autopilot
+
+Generated 2026-08-01T05:16:10.852Z
+
+- **Healer:** resident MAPE-K loop (lib/autonomy/reconciler.ts) — no agent, no session, no human
+- **Plan / dial:** SANDBOX / AGGRESSIVE
+- **Cycle budget:** 3 per case
+
+## Headline
+
+| Metric | Value |
+| --- | --- |
+| Repair rate (in-catalogue, unattended) | **100%** (1/1) |
+| Detection rate | 100% (1/1) |
+| Median cycles to detect | 1 |
+| Median cycles to repair | 1 |
+| Over-corrected (secured into uselessness) | 0 |
+| Degraded (made worse) | 0 |
+| **Control false positives** — findings raised on a healthy backend | **0** |
+| **Control unrequested mutations** | **0** |
+| Out-of-catalogue faults repaired | 0/0 |
+| Model tokens spent across the whole suite | 0 |
+
+Cycles, not seconds: one cycle is one full pass of the maintenance loop. Wall-clock MTTR is `cycles x cadence`; this platform reconciles every minute on every plan, so a 2-cycle repair is roughly a 2-minute repair in production.
+
+## Per case
+
+| Case | Task | Scope | Severity | Result | Detect | Repair | Evidence after |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| `rls-cross-tenant-read` | mitigation | in-catalogue | critical | PASS | 1 | 1 | role authenticated with sub=11111111 read 2 own row(s) and 0 row(s) belonging to another user |
+
+## What each verdict means
+
+- **PASS** — an oracle outside the control plane confirms the defect is gone *and* the legitimate path still works.
+- **FAIL (over-corrected)** — the defect is gone because the feature is broken. Scored as a failure.
+- **VOID** — the injection did not produce the fault, so nothing can be concluded. Never counted as a pass.

--- a/bench/selfops/run.ts
+++ b/bench/selfops/run.ts
@@ -1,0 +1,123 @@
+/**
+ * SELFOPS-BENCH — CLI
+ * ===================
+ *
+ *   npm run bench:selfops
+ *   BENCH_DATABASE_URL=postgres://… npm run bench:selfops -- --cycles 20 --out results/
+ *
+ * Writes a JSON result set and a Markdown report. Both are meant to be
+ * published together: the Markdown is the claim, the JSON is the receipt.
+ *
+ * SAFETY. Every case provisions its own throwaway user, project and workspace
+ * schema, and drops them in a `finally`. It still creates real rows in whatever
+ * database it points at, so it refuses to run against anything that looks like
+ * production unless explicitly forced.
+ */
+
+// FIRST — pins DATABASE_URL for Prisma, the probe pools and every detector to
+// the same instance the oracle grades. Must precede every other import.
+import { assertNotProduction, redactedUrl } from './env'
+
+import * as fs from 'fs'
+import * as path from 'path'
+
+import { CORPUS_V1 } from './corpus'
+import { runSuite, DEFAULT_MAX_CYCLES } from './harness'
+import { score, toMarkdown, toConsole, stabilityReport } from './report'
+import type { CaseResult } from './types'
+import { backenlyLane, laneInfo, disconnectLane } from './adapters/backenly'
+import { closeOracle } from './oracle'
+
+function arg(name: string, fallback?: string): string | undefined {
+  const i = process.argv.indexOf(`--${name}`)
+  return i >= 0 && process.argv[i + 1] ? process.argv[i + 1] : fallback
+}
+
+async function main(): Promise<void> {
+  assertNotProduction()
+
+  const maxCycles = Number(arg('cycles', String(DEFAULT_MAX_CYCLES)))
+  const outDir = arg('out', path.join('bench', 'selfops', 'results'))!
+  const only = arg('only')
+
+  const cases = only ? CORPUS_V1.filter((c) => c.id === only) : CORPUS_V1
+  if (cases.length === 0) {
+    throw new Error(`No case matched --only ${only}. Known: ${CORPUS_V1.map((c) => c.id).join(', ')}`)
+  }
+
+  // A single run is an anecdote. `--repeat` exists so the headline can be a
+  // claim: same corpus, fresh projects every time, and the spread reported
+  // alongside the median. A metric that moves between runs is not a property of
+  // the platform, and the only way to know which one you have is to repeat.
+  const repeat = Math.max(1, Number(arg('repeat', '1')))
+
+  console.log(
+    `\nselfops-bench v1 — ${cases.length} case(s), ${maxCycles} cycle budget` +
+    (repeat > 1 ? `, ${repeat} runs` : '') + `\n` +
+    `database: ${redactedUrl()}\n`,
+  )
+
+  const runs: CaseResult[][] = []
+  for (let r = 1; r <= repeat; r++) {
+    if (repeat > 1) console.log(`\n── run ${r}/${repeat} ─────────────────────────────`)
+    runs.push(
+      await runSuite(cases, backenlyLane, {
+        maxCycles,
+        onProgress: (caseId, cycle, tick) => {
+          const bits = [
+            `findings=${tick.openFindings}`,
+            `attempted=${tick.attempted}`,
+            `applied=${tick.applied}`,
+            tick.escalated ? `escalated=${tick.escalated}` : '',
+            tick.note ? `(${tick.note})` : '',
+          ].filter(Boolean)
+          console.log(`  ${caseId} · cycle ${cycle} · ${bits.join(' ')}`)
+        },
+      }),
+    )
+  }
+
+  // The last run is the one written out in full; stability is computed across all.
+  const results = runs[runs.length - 1]
+  const card = score(results, backenlyLane.name)
+  console.log(toConsole(results, card))
+
+  if (repeat > 1) {
+    console.log(stabilityReport(runs, cases.map((c) => c.id)))
+  }
+
+  const meta = {
+    healer: backenlyLane.healer,
+    autonomyLevel: laneInfo.resolvedLevel,
+    plan: laneInfo.plan,
+    maxCycles,
+  }
+
+  fs.mkdirSync(outDir, { recursive: true })
+  const stamp = new Date().toISOString().replace(/[:.]/g, '-')
+  const jsonPath = path.join(outDir, `${backenlyLane.name}-${stamp}.json`)
+  const mdPath = path.join(outDir, `${backenlyLane.name}-${stamp}.md`)
+
+  fs.writeFileSync(jsonPath, JSON.stringify({ meta, card, results }, null, 2))
+  fs.writeFileSync(mdPath, toMarkdown(results, card, meta))
+
+  console.log(`  receipts: ${jsonPath}`)
+  console.log(`            ${mdPath}\n`)
+
+  // A harness error means the suite did not measure what it claims to measure.
+  // Exit non-zero so CI cannot report a green run over a broken experiment.
+  if (card.errors > 0) {
+    console.error(`${card.errors} case(s) failed to run. The suite did not measure them.`)
+    process.exitCode = 1
+  }
+}
+
+main()
+  .catch((err) => {
+    console.error(`\nselfops-bench failed: ${err?.message ?? err}\n`)
+    process.exitCode = 1
+  })
+  .finally(async () => {
+    await disconnectLane()
+    await closeOracle()
+  })

--- a/bench/selfops/types.ts
+++ b/bench/selfops/types.ts
@@ -1,0 +1,233 @@
+/**
+ * SELFOPS-BENCH — contracts
+ * =========================
+ *
+ * A benchmark for autonomous backend self-maintenance: inject a real fault into
+ * a real backend, then measure whether the platform detects it, repairs it, and
+ * leaves the backend working — without a human or an agent session.
+ *
+ * The taxonomy is borrowed deliberately, not invented. AIOpsLab (Microsoft
+ * Research, arXiv:2501.06706) established the four tasks — detection,
+ * localization, root-cause analysis, mitigation — for autonomous cloud
+ * operations on Kubernetes microservices. This suite is the same taxonomy
+ * instantiated on a backend data plane (Postgres + RLS + generated API
+ * surface), which is the layer AIOpsLab and ITBench do not cover.
+ *
+ * ── The one rule that makes the numbers worth anything ──────────────────────
+ *
+ * A case is NEVER scored by asking the platform's own detector whether the
+ * problem is gone. That is self-grading, and it is how a suite ends up
+ * measuring the agreement of a probe with itself.
+ *
+ * Every case is scored by an `Oracle` that observes the backend from OUTSIDE
+ * the platform's control plane — connecting to Postgres under the same role and
+ * the same request claims that PostgREST uses to serve an end user. If the
+ * oracle can read another tenant's rows, the backend is vulnerable, whatever
+ * the dashboard says.
+ *
+ * ── Why an Observation has two axes and not one ─────────────────────────────
+ *
+ * "Is it fixed?" is the wrong question, because the cheapest way to make a
+ * vulnerability disappear is to break the feature. A deny-all RLS policy passes
+ * every security check ever written and also means the customer's app returns
+ * nothing. So every observation reports two independent facts:
+ *
+ *   vulnerable  — the defect is reproducible from outside
+ *   functional  — the legitimate path still works (the owner can still read
+ *                 their own rows, the API still answers, the insert still lands)
+ *
+ * which yields four verdicts instead of two, and only one of them is a pass:
+ *
+ *   !vulnerable && functional   → HEALED         the only success
+ *    vulnerable && functional   → NOT_REPAIRED   still broken
+ *   !vulnerable && !functional  → OVER_CORRECTED secured into uselessness
+ *    vulnerable && !functional  → DEGRADED       made it worse
+ *
+ * OVER_CORRECTED is scored as a FAILURE, and it is the metric a platform that
+ * heals by locking doors will lose on. Reporting it is the point.
+ */
+
+/** The AIOpsLab task class a case exercises. */
+export type AiopsTask = 'detection' | 'localization' | 'rca' | 'mitigation'
+
+/**
+ * Whether the fault is inside the platform's declared invariant catalogue.
+ *
+ * `out_of_catalogue` cases are faults NOBODY on this platform claims to detect.
+ * They exist so the corpus cannot be tuned to the detector set — a suite whose
+ * every case maps onto an existing probe is teaching to the test, and any
+ * reviewer will say so. Expect these to fail. Publish them failing.
+ */
+export type CatalogueScope = 'in_catalogue' | 'out_of_catalogue'
+
+/**
+ * A reading of the backend taken from outside the control plane.
+ *
+ * `evidence` must be the concrete thing observed ("role authenticated with
+ * sub=A read 3 rows belonging to sub=B"), never a restatement of the verdict.
+ * It is what a skeptical reader checks instead of trusting the boolean.
+ */
+export interface Observation {
+  /** The defect is reproducible right now. */
+  vulnerable: boolean
+  /** The legitimate, intended use of this backend still works. */
+  functional: boolean
+  /** What was actually observed, in one line. Goes into the published report. */
+  evidence: string
+}
+
+export type Verdict =
+  | 'healed'          // !vulnerable && functional  — the only pass
+  | 'not_repaired'    //  vulnerable && functional
+  | 'over_corrected'  // !vulnerable && !functional
+  | 'degraded'        //  vulnerable && !functional
+  | 'never_faulted'   // the injection did not produce the fault — case is void
+  | 'harness_error'   // the case could not be run; never counted as a pass
+
+/** Derive the verdict from a post-run observation. Total and pure. */
+export function verdictFor(after: Observation): Exclude<Verdict, 'never_faulted' | 'harness_error'> {
+  if (after.vulnerable) return after.functional ? 'not_repaired' : 'degraded'
+  return after.functional ? 'healed' : 'over_corrected'
+}
+
+/**
+ * Everything a case needs to build and inspect its backend.
+ *
+ * `sql` runs as the OWNER (the platform's own connection) and is how a case
+ * builds and breaks its fixture. Oracles must NOT use it — they use the
+ * role-scoped helpers in `oracle.ts`, because owner connections bypass RLS
+ * (`FORCE ROW LEVEL SECURITY` notwithstanding) and would report a locked table
+ * as readable.
+ */
+export interface CaseContext {
+  projectId: string
+  userId: string
+  /** The workspace schema this project's tables live in. */
+  schema: string
+  /** Execute DDL/DML as the schema owner. Fixture construction only. */
+  sql: (statement: string) => Promise<void>
+  /** Query as the schema owner. Fixture construction only. */
+  query: <T = Record<string, unknown>>(statement: string, params?: unknown[]) => Promise<T[]>
+  /**
+   * Create a table the way THIS PLATFORM creates tables, and register it in
+   * whatever control plane the platform keeps.
+   *
+   * Cases must use this instead of raw `CREATE TABLE`, and the reason is a bug
+   * this harness shipped with. Creating fixture tables with plain DDL left them
+   * invisible to Backenly's control plane, so every case's backend arrived
+   * carrying `orphan_table` and `workflow_broken` findings that had nothing to
+   * do with the injected fault. Under the 2-minute mutation cooldown those
+   * spurious findings consumed the repair budget first, and the actual fault —
+   * a missing index — was starved for twelve straight cycles and scored as
+   * "the platform cannot fix an index".
+   *
+   * A benchmark fixture has to be a well-formed project on the platform under
+   * test, or it measures the malformation instead of the fault.
+   *
+   * @param name        table name, unqualified
+   * @param columnsSql  the column list, e.g. `id uuid PRIMARY KEY, user_id uuid NOT NULL`
+   */
+  createTable: (name: string, columnsSql: string) => Promise<void>
+}
+
+export interface FaultCase {
+  /** Stable id — appears in the published report and must never be reused. */
+  id: string
+  title: string
+  task: AiopsTask
+  scope: CatalogueScope
+  /**
+   * Real-world severity if this shipped, independent of whether we detect it.
+   * `critical` = data exposure or total outage.
+   */
+  severity: 'critical' | 'warning' | 'info'
+  /**
+   * One line on what breaks in production when this fault is live. This is the
+   * "why should anyone care" column of the report.
+   */
+  impact: string
+  /**
+   * True when this fault can be expressed on every lane in the comparison.
+   * Only cross-platform cases are scored in a head-to-head table; the rest are
+   * reported in a platform-specific appendix, unscored. Running a suite whose
+   * tasks a competitor's vocabulary cannot express yields a true but
+   * uninformative zero.
+   */
+  crossPlatform: boolean
+
+  /** Build a CORRECT, working backend. Must leave the oracle clean. */
+  setup(ctx: CaseContext): Promise<void>
+  /** Break it. Must leave the oracle vulnerable and/or non-functional. */
+  inject(ctx: CaseContext): Promise<void>
+  /** Observe from outside the control plane. Called before and after healing. */
+  observe(ctx: CaseContext): Promise<Observation>
+}
+
+/** What one lane (platform under test) must implement to be benchmarked. */
+export interface LaneAdapter {
+  /** Lane name as it appears in the report, e.g. "backenly-autopilot". */
+  name: string
+  /** One line describing who or what does the repairing on this lane. */
+  healer: string
+  /** Provision an empty project + workspace schema. */
+  provision(): Promise<CaseContext>
+  /**
+   * Advance the platform's maintenance loop by exactly one cycle.
+   * Returns what that cycle did, for the per-tick trace.
+   *
+   * Lanes whose healer is an agent session implement this as one agent turn.
+   * Lanes with no healer at all return a zeroed tick, and their MTTR is
+   * correctly reported as unbounded rather than as a missing value.
+   */
+  tick(ctx: CaseContext): Promise<TickResult>
+  /** Tear down everything provisioned. Must not throw. */
+  teardown(ctx: CaseContext): Promise<void>
+}
+
+export interface TickResult {
+  /** Findings the platform currently holds open for this project. */
+  openFindings: number
+  /** Repairs the platform attempted this cycle. */
+  attempted: number
+  /** Repairs the platform applied this cycle. */
+  applied: number
+  /** Gaps routed to a human instead of repaired. */
+  escalated: number
+  /** Cycle refused to act (change freeze, breaker, cooldown). */
+  blocked: boolean
+  /** Why it refused, when it did. */
+  note?: string
+  /**
+   * Model tokens spent by this cycle. The loop's cost story is only credible
+   * if it is measured, so a lane that spends tokens must report them.
+   */
+  tokensSpent: number
+}
+
+export interface CaseResult {
+  caseId: string
+  lane: string
+  task: AiopsTask
+  scope: CatalogueScope
+  severity: FaultCase['severity']
+  crossPlatform: boolean
+  verdict: Verdict
+  /** Observation taken immediately after injection — proves the fault was real. */
+  before: Observation | null
+  /** Observation taken after the loop stopped changing things. */
+  after: Observation | null
+  /**
+   * Cycles until the platform first held an open finding for this fault.
+   * null = never detected within the budget.
+   */
+  ticksToDetect: number | null
+  /** Cycles until the oracle first read healthy. null = never healed. */
+  ticksToRepair: number | null
+  ticksRun: number
+  fixesApplied: number
+  escalations: number
+  tokensSpent: number
+  /** Per-cycle trace, published alongside the score. */
+  trace: TickResult[]
+  error?: string
+}

--- a/lib/ai/build-runtime/build-lock.ts
+++ b/lib/ai/build-runtime/build-lock.ts
@@ -26,6 +26,7 @@
  */
 
 import { prisma } from '@/lib/db/prisma'
+import { Pool, type PoolClient } from 'pg'
 
 // ── Config ─────────────────────────────────────────────────────────────────────
 
@@ -84,22 +85,118 @@ function projectToLockKey(projectId: string): number {
 }
 
 // ── PostgreSQL advisory locks ─────────────────────────────────────────────────
+//
+// THE POOL BUG THIS EXISTS TO FIX
+// -------------------------------
+// `pg_advisory_lock` is SESSION-scoped. These two calls used to go through
+// `prisma.$queryRaw`, which draws an arbitrary connection from the pool — so the
+// lock could be taken on connection A and the unlock issued on connection B.
+// `pg_advisory_unlock` on a session that does not hold the lock does not throw:
+// it logs a warning and returns FALSE. The return value was discarded, so the
+// failure was completely silent and the lock stayed held on connection A until
+// that connection happened to be recycled.
+//
+// The old code knew: "if Prisma happens to reuse the original connection, this
+// will succeed." Correctness rested on pool luck.
+//
+// The consequence was not theoretical. selfops-bench reproduces it on demand:
+// after a repair, later repairs for that project fail with "Another auto-fix is
+// in progress" while ZERO BackgroundJobs are running — so `reapStaleJobs` finds
+// nothing to reap (release had already marked the job `completed`), gives up,
+// and the project loses autonomous repair entirely until the connection
+// recycles. That is the same silent-stall shape as the thirteen-day
+// `attempted=0` outage: every ledger row looks like activity.
+//
+// So the lock now holds a DEDICATED connection for its whole lifetime. Acquire
+// and release are provably the same session, and the unlock result is checked
+// rather than assumed. If the process dies the connection dies with it, which
+// releases the lock — the correct behaviour for an advisory lock.
 
+/**
+ * Connections used solely to hold advisory locks. Separate from Prisma's pool
+ * because a connection parked holding a lock must not be handed to unrelated
+ * queries, and because Prisma gives no API to pin one.
+ */
+const lockPool = new Pool({
+  connectionString: process.env.DATABASE_URL,
+  // Locks are held briefly and one at a time per project. This ceiling bounds
+  // how many projects can mutate concurrently on one instance.
+  max: 10,
+})
+
+/** lockKey → the connection holding it. The pin that makes unlock correct. */
+const _heldLockClients = new Map<number, PoolClient>()
+
+/**
+ * Take the advisory lock on a connection we keep checked out.
+ * Returns false without leaking the connection when the lock is already held.
+ */
 async function pgTryAdvisoryLock(key: number): Promise<boolean> {
+  // Already held by this process — do not double-acquire. pg advisory locks are
+  // re-entrant per session and would then need matching unlocks to release.
+  if (_heldLockClients.has(key)) return false
+
+  let client: PoolClient
   try {
-    const rows = await prisma.$queryRaw<[{ acquired: boolean }]>`
-      SELECT pg_try_advisory_lock(${key}::bigint) AS acquired
-    `
-    return rows[0]?.acquired === true
+    client = await lockPool.connect()
   } catch {
+    return false
+  }
+
+  try {
+    const res = await client.query<{ acquired: boolean }>(
+      'SELECT pg_try_advisory_lock($1::bigint) AS acquired',
+      [key],
+    )
+    if (res.rows[0]?.acquired === true) {
+      _heldLockClients.set(key, client)
+      return true
+    }
+    client.release()
+    return false
+  } catch {
+    client.release()
     return false
   }
 }
 
+/**
+ * Release the advisory lock on the SAME connection that took it.
+ *
+ * Loud on failure: a silent false here is precisely the bug above, and a lock
+ * that fails to release costs the project its autonomous repairs.
+ */
 async function pgAdvisoryUnlock(key: number): Promise<void> {
+  const client = _heldLockClients.get(key)
+  if (!client) {
+    // Nothing pinned for this key. Either the lock was never taken by this
+    // process, or it was taken by another instance — in which case stealing it
+    // would be wrong. Both are no-ops, not errors.
+    return
+  }
+
+  _heldLockClients.delete(key)
   try {
-    await prisma.$queryRaw`SELECT pg_advisory_unlock(${key}::bigint)`
-  } catch { /* non-fatal — lock will expire with session */ }
+    const res = await client.query<{ released: boolean }>(
+      'SELECT pg_advisory_unlock($1::bigint) AS released',
+      [key],
+    )
+    if (res.rows[0]?.released !== true) {
+      console.error(
+        `[BuildLock] pg_advisory_unlock(${key}) returned false on the session that ` +
+        `holds it. This should be impossible; the connection is being destroyed so ` +
+        `the lock cannot leak.`,
+      )
+      // Destroying the connection guarantees the lock is dropped server-side.
+      client.release(new Error('advisory unlock failed'))
+      return
+    }
+    client.release()
+  } catch (err: any) {
+    console.error(`[BuildLock] advisory unlock error for ${key}: ${err?.message}`)
+    // Destroy rather than return a possibly-locked connection to the pool.
+    client.release(new Error('advisory unlock threw'))
+  }
 }
 
 // ── In-memory fallback lock ────────────────────────────────────────────────────
@@ -150,9 +247,10 @@ async function reapStaleJobs(projectId: string, lockKey: number): Promise<boolea
 
     if (reaped.count === 0) return false
 
-    // Best-effort: try to release the advisory lock from any session that may hold it.
-    // pg_advisory_unlock returns false if the calling session does not hold the lock,
-    // but if Prisma happens to reuse the original connection, this will succeed.
+    // Release the advisory lock if THIS process is the one pinning it. When the
+    // holder is another instance, `pgAdvisoryUnlock` is a no-op by design —
+    // forcibly stealing a lock held elsewhere is how two workers end up mutating
+    // one project at once, which is the exact race the lock exists to prevent.
     await pgAdvisoryUnlock(lockKey)
 
     return true

--- a/package.json
+++ b/package.json
@@ -38,7 +38,8 @@
     "mixed-eval:flows": "MODES=B tsx scripts/mixed-eval.ts",
     "mixed-eval:chaos": "MODES=C tsx scripts/mixed-eval.ts",
     "migrate:api-keys": "tsx scripts/migrate-api-keys-to-hash.ts",
-    "cleanup:tokens": "tsx scripts/cleanup-expired-tokens.ts"
+    "cleanup:tokens": "tsx scripts/cleanup-expired-tokens.ts",
+    "bench:selfops": "tsx bench/selfops/run.ts"
   },
   "dependencies": {
     "@amplitude/unified": "^1.1.21",

--- a/tests/bench/build-lock-advisory.spec.ts
+++ b/tests/bench/build-lock-advisory.spec.ts
@@ -1,0 +1,90 @@
+/**
+ * The build lock must actually release. Against a real Postgres.
+ *
+ * ── The bug ─────────────────────────────────────────────────────────────────
+ * `pg_advisory_lock` is SESSION-scoped, and both the lock and the unlock used to
+ * be issued through Prisma's connection POOL. The unlock could therefore land on
+ * a different connection than the lock. `pg_advisory_unlock` on a session that
+ * does not hold the lock does not throw — it returns FALSE — and the return
+ * value was discarded. So the lock silently stayed held until that pooled
+ * connection was recycled, and every subsequent mutation for that project failed
+ * with "Another auto-fix is in progress" while zero jobs were running.
+ *
+ * `reapStaleJobs` could not rescue it: release had already marked the
+ * BackgroundJob `completed`, so there was nothing stale to reap.
+ *
+ * selfops-bench reproduced it on demand (fk-column-unindexed never repaired in
+ * 12 cycles). This pins it shut at the primitive.
+ *
+ * Mocking is pointless here — what is being tested IS the interaction between
+ * pg session semantics and a connection pool, so it needs a real database.
+ */
+
+import { Pool } from 'pg'
+import { acquireBuildLock, releaseBuildLock } from '@/lib/ai/build-runtime/build-lock'
+
+const CONN = process.env.BENCH_DATABASE_URL || process.env.DATABASE_URL || ''
+const projectId = `lock-test-${Date.now()}`
+
+/** Ask Postgres directly whether ANY session holds our advisory lock. */
+async function advisoryLocksHeld(): Promise<number> {
+  const pool = new Pool({ connectionString: CONN, max: 1 })
+  try {
+    const res = await pool.query<{ n: string }>(
+      `SELECT count(*)::text AS n FROM pg_locks WHERE locktype = 'advisory'`,
+    )
+    return Number(res.rows[0]?.n ?? 0)
+  } finally {
+    await pool.end().catch(() => {})
+  }
+}
+
+describe('build lock advisory release', () => {
+  it('releases the advisory lock so the same project can lock again', async () => {
+    const first = await acquireBuildLock(projectId, 'modify')
+    expect(first.acquired).toBe(true)
+    expect(first.handle).toBeDefined()
+
+    // While held, a second acquisition for the SAME project must fail — that is
+    // the mutual exclusion the lock exists to provide.
+    const contended = await acquireBuildLock(projectId, 'modify')
+    expect(contended.acquired).toBe(false)
+
+    await releaseBuildLock(first.handle)
+
+    // The whole point: after release, the project is lockable again. Before the
+    // fix this returned false forever whenever the unlock had been routed to a
+    // different pooled connection.
+    const second = await acquireBuildLock(projectId, 'modify')
+    expect(second.acquired).toBe(true)
+    await releaseBuildLock(second.handle)
+  }, 30_000)
+
+  it('leaves no advisory lock held in the database after release', async () => {
+    const before = await advisoryLocksHeld()
+
+    const lock = await acquireBuildLock(`${projectId}-leak`, 'modify')
+    expect(lock.acquired).toBe(true)
+    await releaseBuildLock(lock.handle)
+
+    // Not "fewer than before" — exactly back to baseline. A leaked advisory lock
+    // is invisible to every application-level check; only pg_locks can see it.
+    const after = await advisoryLocksHeld()
+    expect(after).toBe(before)
+  }, 30_000)
+
+  it('survives repeated acquire/release cycles without leaking', async () => {
+    const before = await advisoryLocksHeld()
+
+    // Ten cycles is enough to exhaust a small pool and force the unlock onto a
+    // connection other than the one that locked — the exact condition that made
+    // the original bug intermittent rather than obvious.
+    for (let i = 0; i < 10; i++) {
+      const lock = await acquireBuildLock(`${projectId}-cycle-${i}`, 'modify')
+      expect(lock.acquired).toBe(true)
+      await releaseBuildLock(lock.handle)
+    }
+
+    expect(await advisoryLocksHeld()).toBe(before)
+  }, 60_000)
+})

--- a/tests/bench/selfops-harness.spec.ts
+++ b/tests/bench/selfops-harness.spec.ts
@@ -1,0 +1,250 @@
+/**
+ * selfops-bench — the protocol, verified without a database.
+ *
+ * The database-backed lane needs Postgres and runs in CI. The rules that decide
+ * what a run MEANS are pure, and they are the part a reader of the published
+ * numbers is trusting. Each one below is a way a self-run benchmark can flatter
+ * its author, asserted closed:
+ *
+ *   • A fixture that was already broken cannot be "repaired".
+ *   • An injection that did not take cannot count as a pass.
+ *   • Removing a vulnerability by breaking the feature is a FAILURE.
+ *   • Void and errored cases stay out of the denominator.
+ *   • The platform's own claim about what it fixed never decides the verdict.
+ *
+ * The lane here is a stub ON PURPOSE — this suite tests the scoring protocol,
+ * not the reconciler. The reconciler is tested by running it (CI job
+ * `selfops-bench`), because a stubbed loop that "heals" would prove nothing,
+ * which is the exact vacuous-pass trap the probe suite already fell into once.
+ */
+
+import { runCase } from '@/bench/selfops/harness'
+import { score } from '@/bench/selfops/report'
+import { verdictFor } from '@/bench/selfops/types'
+import type {
+  CaseContext,
+  FaultCase,
+  LaneAdapter,
+  Observation,
+  TickResult,
+} from '@/bench/selfops/types'
+
+// ── A lane that does nothing, and one that "fixes" whatever it is told to ────
+
+const ctx: CaseContext = {
+  projectId: 'p1',
+  userId: 'u1',
+  schema: 'workspace_p1',
+  sql: async () => {},
+  query: async () => [],
+  createTable: async () => {},
+}
+
+const idleTick: TickResult = {
+  openFindings: 0,
+  attempted: 0,
+  applied: 0,
+  escalated: 0,
+  blocked: false,
+  tokensSpent: 0,
+}
+
+function laneThat(ticks: Partial<TickResult>[]): LaneAdapter {
+  let i = 0
+  return {
+    name: 'stub',
+    healer: 'stub',
+    provision: async () => ctx,
+    tick: async () => ({ ...idleTick, ...(ticks[i++] ?? {}) }),
+    teardown: async () => {},
+  }
+}
+
+/** A case whose observations are scripted, so the protocol is what is tested. */
+function caseWith(
+  observations: Observation[],
+  overrides: Partial<FaultCase> = {},
+): FaultCase {
+  let i = 0
+  return {
+    id: 'synthetic',
+    title: 'synthetic',
+    task: 'mitigation',
+    scope: 'in_catalogue',
+    severity: 'critical',
+    crossPlatform: true,
+    impact: 'synthetic',
+    setup: async () => {},
+    inject: async () => {},
+    observe: async () => observations[Math.min(i++, observations.length - 1)],
+    ...overrides,
+  }
+}
+
+const ok: Observation = { vulnerable: false, functional: true, evidence: 'clean' }
+const broken: Observation = { vulnerable: true, functional: true, evidence: 'leaking' }
+const lockedOut: Observation = { vulnerable: false, functional: false, evidence: 'deny-all' }
+
+// ── verdictFor ───────────────────────────────────────────────────────────────
+
+describe('verdictFor', () => {
+  it('passes only when the defect is gone AND the feature still works', () => {
+    expect(verdictFor(ok)).toBe('healed')
+  })
+
+  it('scores a vulnerability removed by breaking the feature as a FAILURE', () => {
+    // The whole reason the Observation has two axes. A one-axis benchmark
+    // ("is it still leaking?") scores this identically to a real repair.
+    expect(verdictFor(lockedOut)).toBe('over_corrected')
+  })
+
+  it('distinguishes still-broken from made-worse', () => {
+    expect(verdictFor(broken)).toBe('not_repaired')
+    expect(verdictFor({ vulnerable: true, functional: false, evidence: '' })).toBe('degraded')
+  })
+})
+
+// ── The experimental protocol ────────────────────────────────────────────────
+
+describe('runCase protocol', () => {
+  it('voids a case whose fixture did not start healthy', async () => {
+    // baseline observation is already broken → nothing can be attributed to
+    // the injection, so the case must not be scored either way.
+    const result = await runCase(caseWith([broken, broken, ok]), laneThat([{ applied: 1 }]))
+
+    expect(result.verdict).toBe('harness_error')
+    expect(result.error).toMatch(/did not start healthy/i)
+    expect(result.ticksRun).toBe(0)
+  })
+
+  it('voids a case whose injection did not take, and never calls it a pass', async () => {
+    // healthy baseline, still healthy after inject → the fault never existed.
+    const result = await runCase(caseWith([ok, ok]), laneThat([{ applied: 1 }]))
+
+    expect(result.verdict).toBe('never_faulted')
+    expect(result.verdict).not.toBe('healed')
+    expect(result.ticksRun).toBe(0)
+  })
+
+  it('records a repair only when the oracle reads healthy, not when the loop claims success', async () => {
+    // The lane reports applied=1 on cycle 1 while the oracle still reads broken.
+    // The repair must not be credited until the oracle actually flips, on cycle 2.
+    const result = await runCase(
+      caseWith([ok, broken, broken, ok]),
+      laneThat([{ applied: 1, openFindings: 1 }, { applied: 1, openFindings: 1 }]),
+    )
+
+    expect(result.verdict).toBe('healed')
+    expect(result.ticksToRepair).toBe(2)
+    expect(result.ticksToDetect).toBe(1)
+  })
+
+  it('fails a case where the loop removed the vulnerability by locking everyone out', async () => {
+    const result = await runCase(
+      caseWith([ok, broken, lockedOut]),
+      laneThat([{ applied: 1, openFindings: 1 }]),
+    )
+
+    expect(result.verdict).toBe('over_corrected')
+    expect(result.ticksToRepair).toBeNull()
+    // The loop still reports it applied a fix — recorded, but not decisive.
+    expect(result.fixesApplied).toBe(1)
+  })
+
+  it('stops early once the loop has gone idle instead of burning the budget', async () => {
+    const result = await runCase(caseWith([ok, broken]), laneThat([]), { maxCycles: 40 })
+
+    expect(result.verdict).toBe('not_repaired')
+    expect(result.ticksRun).toBeLessThan(10)
+  })
+})
+
+// ── Scoring ──────────────────────────────────────────────────────────────────
+
+describe('score', () => {
+  const result = (over: Partial<ReturnType<typeof baseResult>>) => ({ ...baseResult(), ...over })
+
+  function baseResult() {
+    return {
+      caseId: 'c',
+      lane: 'stub',
+      task: 'mitigation' as const,
+      scope: 'in_catalogue' as const,
+      severity: 'critical' as const,
+      crossPlatform: true,
+      verdict: 'healed' as const,
+      before: broken,
+      after: ok,
+      ticksToDetect: 1,
+      ticksToRepair: 1,
+      ticksRun: 1,
+      fixesApplied: 1,
+      escalations: 0,
+      tokensSpent: 0,
+      trace: [],
+    }
+  }
+
+  it('keeps void and errored cases out of the denominator', () => {
+    const card = score(
+      [
+        result({ caseId: 'a', verdict: 'healed' }),
+        result({ caseId: 'b', verdict: 'never_faulted' }),
+        result({ caseId: 'c', verdict: 'harness_error' }),
+      ],
+      'stub',
+    )
+
+    // 1 of 1 scorable — not 1 of 3, and not 3 of 3.
+    expect(card.scored).toBe(1)
+    expect(card.repairRate).toBe(1)
+    expect(card.void).toBe(1)
+    expect(card.errors).toBe(1)
+  })
+
+  it('counts an over-correction against the repair rate', () => {
+    const card = score(
+      [
+        result({ caseId: 'a', verdict: 'healed' }),
+        result({ caseId: 'b', verdict: 'over_corrected', after: lockedOut, ticksToRepair: null }),
+      ],
+      'stub',
+    )
+
+    expect(card.repairRate).toBe(0.5)
+    expect(card.overCorrected).toBe(1)
+  })
+
+  it('reports out-of-catalogue faults separately so they cannot pad the headline', () => {
+    const card = score(
+      [
+        result({ caseId: 'a', verdict: 'healed' }),
+        result({ caseId: 'b', verdict: 'not_repaired', scope: 'out_of_catalogue' }),
+      ],
+      'stub',
+    )
+
+    expect(card.repairRate).toBe(1)          // in-catalogue only
+    expect(card.outOfCatalogue.total).toBe(1)
+    expect(card.outOfCatalogue.healed).toBe(0)
+  })
+
+  it('counts findings and mutations on the healthy control as false positives', () => {
+    const card = score(
+      [
+        result({
+          caseId: 'control-healthy-backend',
+          verdict: 'never_faulted',
+          fixesApplied: 2,
+          trace: [{ ...idleTick, openFindings: 3 }, { ...idleTick, openFindings: 1 }],
+        }),
+      ],
+      'stub',
+    )
+
+    expect(card.control.findingsRaised).toBe(3)
+    expect(card.control.mutationsApplied).toBe(2)
+    // The control must never contribute to the repair rate.
+    expect(card.scored).toBe(0)
+  })
+})


### PR DESCRIPTION
## What this is

`bench/selfops/` — a benchmark for autonomous backend self-maintenance. It injects real faults
into real backends and grades them from **outside the control plane**, connecting as an
end-user Postgres role with `request.jwt.claims` set, never by asking the platform's own
probes whether the problem is gone.

Taxonomy is borrowed from AIOpsLab (Microsoft Research, arXiv:2501.06706) rather than invented:
detection, localization, RCA, mitigation. 12 cases — 7 in-catalogue, 1 healthy control, 4
deliberately outside the invariant catalogue.

## The production bug it found

`pg_advisory_lock` is session-scoped, but `build-lock.ts` issued the lock and the unlock
through Prisma's connection **pool**, so the unlock could land on a different connection.
`pg_advisory_unlock` on a session that does not hold the lock returns `false` rather than
throwing, and that return value was discarded.

When it lost that race the lock stayed held until the connection recycled, and every later
mutation for that project failed with `Another auto-fix is in progress` while **zero jobs were
running** — so the stale-job reaper found nothing to reap and gave up. The project silently
lost autonomous repair, with every ledger row still reading as activity.

Fixed by pinning one connection for the lock's lifetime and checking the unlock result.
`tests/bench/build-lock-advisory.spec.ts` asserts against `pg_locks` directly, and was
**verified to fail against the old implementation** before being accepted.

This affects every mutation path in the product, not just the benchmark.

## Results

Three runs each on Windows/PG16.10, Windows/PG17.6, and Linux CI/PG16. Identical per-case
verdicts across all nine runs.

| Metric | Value |
| --- | --- |
| Repair rate (in-catalogue, unattended) | 71% (5/7) |
| Detection rate | 100% |
| Over-corrected | 0 |
| Control false positives | 0 findings, 0 mutations |
| Out-of-catalogue repaired | 1/4 |
| Model tokens, whole suite | 0 |

Two critical in-catalogue misses are **detected and not repaired**, and are documented rather
than fixed here so the measurement stays separate from the product work that closes them.

Running on Linux also exposed a defect in the instrument: detection was sampled after each
cycle and raced the finding reaper, producing an impossible `detect=- repair=2`. Fixed.

## Not included

The two RLS remediation gaps. Fixing them in the same change that expanded the corpus would
make the number move for reasons tangled up with the measurement.