### PR TITLE
Make npm run lint pass on a clean checkout

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,6 +57,14 @@ jobs:
       - name: Typecheck
         run: npx tsc --noEmit -p tsconfig.json
 
+      # CONTRIBUTING.md and README.md both tell contributors to run this before
+      # a PR, but nothing enforced it, so main drifted to 17 lint errors and the
+      # first command a new contributor ran failed on code they never touched
+      # (#8). `next build` cannot catch it either: next.config.js sets
+      # eslint.ignoreDuringBuilds. Only running it here keeps it green.
+      - name: Lint
+        run: npm run lint
+
       # Under PostgREST the API IS the schema, so an ApiDefinition row decides
       # nothing — it is a second, writable copy of a fact the PostgreSQL catalog
       # already owns, and the only thing a second copy can do is disagree. It

--- a/app/app/billing/billing-panel.tsx
+++ b/app/app/billing/billing-panel.tsx
@@ -495,9 +495,9 @@ export function BillingPanel() {
 
         <div className="mt-5">
           <KitNote tone="info" title="Typed MCP tools have no AI charge">
-            Driving your backend from Claude Code / Cursor over MCP uses your agent's intelligence — the typed tools
+            Driving your backend from Claude Code / Cursor over MCP uses your agent&apos;s intelligence — the typed tools
             (create_table, set_rls, run_query and the rest) compile straight to SQL and cost no credits. AI credits meter
-            Backenly's own LLM work: the natural-language <code className="text-zinc-300">backend_chat</code> tool,
+            Backenly&apos;s own LLM work: the natural-language <code className="text-zinc-300">backend_chat</code> tool,
             function generation, and AI-powered tools. Need a custom plan?{' '}
             <a href="mailto:support@backenly.com" className="text-violet-300 underline underline-offset-2 hover:text-violet-200">Contact sales</a>.
           </KitNote>

--- a/app/app/database/page.tsx
+++ b/app/app/database/page.tsx
@@ -120,7 +120,7 @@ export default function DatabaseRedirectPage() {
               </li>
               <li className="flex items-start gap-2">
                 <ArrowRight className="w-4 h-4 text-indigo-400 flex-shrink-0 mt-0.5" />
-                <span><strong className="text-white">Clear Context:</strong> You always know which project you're working on</span>
+                <span><strong className="text-white">Clear Context:</strong> You always know which project you&apos;re working on</span>
               </li>
               <li className="flex items-start gap-2">
                 <ArrowRight className="w-4 h-4 text-indigo-400 flex-shrink-0 mt-0.5" />

--- a/app/app/deploy/page.tsx
+++ b/app/app/deploy/page.tsx
@@ -221,7 +221,7 @@ export default function DeployPage() {
                 <p className="text-sm text-gray-400 leading-relaxed">
                   It exists privately and safely.
                   <br />
-                  Deploy when you're ready to expose it.
+                  Deploy when you&apos;re ready to expose it.
                 </p>
               </div>
             </div>

--- a/app/app/page.tsx
+++ b/app/app/page.tsx
@@ -271,7 +271,7 @@ export default function DashboardPage() {
                 <>
                   <h3 className="mt-4 text-sm font-semibold text-white">No matching projects</h3>
                   <p className="mt-2 max-w-sm text-sm leading-6 text-zinc-500">
-                    No project matches "{searchQuery.trim()}".
+                    No project matches &quot;{searchQuery.trim()}&quot;.
                   </p>
                 </>
               )}
@@ -423,7 +423,7 @@ function NewProjectModal({
               <span className="h-[5px] w-[5px] rounded-full bg-emerald-400" />
               EU · Hetzner
             </span>
-            <span>Deployed to Backenly's single region.</span>
+            <span>Deployed to Backenly&apos;s single region.</span>
           </div>
 
           {error && (

--- a/app/app/settings/page.tsx
+++ b/app/app/settings/page.tsx
@@ -454,7 +454,7 @@ export default function SettingsPage() {
               <ModalHeader icon={ShieldCheck} title="Save your backup codes" subtitle="Each can be used once" onClose={closeTwoFAModal} />
               <div className="p-5">
                 <KitNote icon={AlertTriangle} tone="warn">
-                  Store these somewhere safe. We won't show them again.
+                  Store these somewhere safe. We won&apos;t show them again.
                 </KitNote>
                 <div className="mt-4 grid grid-cols-2 gap-2 rounded-lg border border-white/[0.07] bg-[#0f1015] p-4">
                   {twoFABackupCodes.map((code, i) => (
@@ -660,7 +660,7 @@ function SecuritySection({
               </div>
               <div className="min-w-0 flex-1">
                 <p className="text-[13px] font-medium text-zinc-100">Send password reset link</p>
-                <p className="mt-0.5 text-[11.5px] text-zinc-500">We'll email a secure link to {user?.email}.</p>
+                <p className="mt-0.5 text-[11.5px] text-zinc-500">We&apos;ll email a secure link to {user?.email}.</p>
               </div>
               <KitButton variant="secondary" size="sm" icon={resetLoading ? undefined : Mail} onClick={onPasswordReset} disabled={resetLoading}>
                 {resetLoading ? <><Loader2 className="h-3.5 w-3.5 animate-spin" /> Sending…</> : 'Send link'}
@@ -668,7 +668,7 @@ function SecuritySection({
             </div>
           ) : (
             <p className="text-[12.5px] text-zinc-400">
-              Your password is managed by <span className="font-medium text-zinc-200">{providerLabel(user?.provider)}</span>. Update it in your provider's account settings.
+              Your password is managed by <span className="font-medium text-zinc-200">{providerLabel(user?.provider)}</span>. Update it in your provider&apos;s account settings.
             </p>
           )}
         </KitCardBody>

--- a/app/auth/forgot-password/page.tsx
+++ b/app/auth/forgot-password/page.tsx
@@ -74,7 +74,7 @@ export default function ForgotPasswordPage() {
               Forgot your<br />password?
             </h2>
             <p className="text-white/80 text-lg">
-              No worries. We'll send you a secure reset link.
+              No worries. We&apos;ll send you a secure reset link.
             </p>
           </motion.div>
         </div>
@@ -113,7 +113,7 @@ export default function ForgotPasswordPage() {
                   It expires in <span className="text-white font-semibold">1 hour</span>.
                 </p>
                 <p className="text-gray-500 text-xs mb-8">
-                  Didn't receive it? Check your spam folder or{' '}
+                  Didn&apos;t receive it? Check your spam folder or{' '}
                   <button
                     onClick={() => setSubmitted(false)}
                     className="text-purple-400 hover:text-purple-300 underline"
@@ -139,7 +139,7 @@ export default function ForgotPasswordPage() {
                 >
                   <h1 className="text-3xl font-black text-white mb-2 tracking-tight">Reset password</h1>
                   <p className="text-gray-400 text-base font-medium">
-                    Enter your email and we'll send you a reset link
+                    Enter your email and we&apos;ll send you a reset link
                   </p>
                 </motion.div>
 

--- a/app/auth/reset-password/page.tsx
+++ b/app/auth/reset-password/page.tsx
@@ -107,7 +107,7 @@ function ResetPasswordForm() {
               </div>
             </motion.div>
             <h2 className="text-4xl font-bold text-white mb-4">Choose a new<br />password</h2>
-            <p className="text-white/80 text-lg">Make it strong and something you'll remember.</p>
+            <p className="text-white/80 text-lg">Make it strong and something you&apos;ll remember.</p>
           </motion.div>
         </div>
       </div>

--- a/components/app/CommandPalette.tsx
+++ b/components/app/CommandPalette.tsx
@@ -227,7 +227,7 @@ export function CommandPalette() {
                 ))}
                 {filteredCommands.length === 0 && (
                   <div className="px-4 py-10 text-center">
-                    <p className="text-[12.5px] text-zinc-500">Nothing matches "{search}".</p>
+                    <p className="text-[12.5px] text-zinc-500">Nothing matches &quot;{search}&quot;.</p>
                   </div>
                 )}
               </div>

--- a/lib/services/ai-functions/route-module-runner.ts
+++ b/lib/services/ai-functions/route-module-runner.ts
@@ -65,7 +65,6 @@ let _esbuildTransformSync:
   | null = null
 function getEsbuildTransformSync() {
   if (_esbuildTransformSync) return _esbuildTransformSync
-  // eslint-disable-next-line @typescript-eslint/no-var-requires
   const req = eval('require') as NodeRequire
   _esbuildTransformSync = req('esbuild').transformSync
   return _esbuildTransformSync!


### PR DESCRIPTION
Fixes #8

Reproduced first: on untouched main, `npm run lint` exits 1 with 17 errors, matching the issue.

Three changes, following the fix plan in the issue:

1. **Escape the 16 unescaped apostrophes/quotes in JSX** with `&apos;`/`&quot;` — the entities the codebase already uses elsewhere. `next lint --fix` turned out not to touch these (react/no-unescaped-entities ships no auto-fixer), so they are fixed by hand. Text content only; no markup or logic changes.

2. **Drop the stale eslint-disable comment** in `lib/services/ai-functions/route-module-runner.ts:68` rather than adding the `@typescript-eslint` plugin. Two reasons: the plugin was never loaded, so the comment has never suppressed anything; and even with the plugin installed the rule cannot fire on that line — `no-var-requires` flags literal `require()` calls, and this line assigns `eval(require)` to a local (`req`), which the rule does not match. So nothing real was being suppressed, and pulling in a new plugin just to legitimize a no-op comment felt like the wrong trade.

3. **Add a Lint step to the `static` CI job** (the step the issue flags as the one that matters). CI had no lint step, and `next.config.js` sets `eslint.ignoreDuringBuilds: true`, so nothing else can catch a regression.

Verified: `npm run lint` exits 0 (remaining react-hooks/exhaustive-deps warnings are pre-existing and untouched — warnings do not fail the run), `npx tsc --noEmit -p tsconfig.json` passes, and `npx jest tests/unit --ci` passes (57 suites, 1029 tests).